### PR TITLE
feat(progression): first-attempt bonus, comeback bonus, interaction logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to KidKode will be documented here.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-06
+
+### Added
+- First-attempt bonus: 1.5x XP (50% extra) when completing a lesson for the first time (#36)
+- Comeback bonus: tiered XP multiplier for returning after 3+ days away — 1.25x (3d), 1.5x (7d), 2x (14d+) (#36)
+- `interaction_events` table (migration 006) for granular kid interaction logging
+- `lib/events.ts` — `logInteractionEvent` / `logInteractionEvents`, fire-and-forget, non-fatal
+- `app/actions/events.ts` — thin server action wrappers for event logging
+- Wrong-answer events logged during quiz and boss battle with question index, selected/correct option
+- Boss HP snapshot events logged after each boss battle answer
+- Section completion time events logged with duration and section type
+- Lesson revisit events logged when a completed lesson is re-entered
+- Section replay events logged when navigating back to an earlier section
+- "FIRST TRY!" card on UnlockScreen when first-attempt bonus is earned
+- "WELCOME BACK!" card on UnlockScreen when comeback bonus is earned
+- Dashboard "Welcome Back!" banner for child accounts returning after 3+ days
+
+### Changed
+- `lesson_progress.attempts` is now incremented on every `completeLesson()` call (#36)
+- `LessonCompletionResult` — added optional `isFirstAttempt`, `bonusXp`, `comebackBonus`
+- `PlayerProfile` — added optional `daysAway` (populated by `loadDashboard`)
+- `UnlockScreen` — `xpEarned` now reflects total XP (base + all bonuses); bonus breakdown shown as separate cards
+- Bonus XP awards use distinct `reason` values (`first_attempt_bonus`, `comeback_bonus`) — idempotent via existing partial unique indexes
+
 ## [1.1.0] - 2026-04-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,18 @@
 # KidKode
 
+## ⚠️ DATABASE — READ BEFORE ANY DB OPERATION
+
+KidKode DB is at **port 55122**, not 54322.
+
+- Correct: `psql postgresql://postgres:postgres@localhost:55122/postgres`
+- Wrong: port 54322 = `supabase_db_travel` (a different project — do not touch)
+- `supabase status` and `config.toml` both lie — they show 54322. Ignore them.
+- Never use `supabase migration up`, `supabase db push`, or `supabase db reset` — they read the wrong port
+- Apply migrations directly: `psql postgresql://postgres:postgres@localhost:55122/postgres -f supabase/migrations/NNN_name.sql`
+- Use `npm run db` to open a psql shell against the correct DB
+
+Background: twice now (2026-03-20, 2026-04-06) operations ran against the travel project's DB at 54322. On 2026-04-06 rows were inserted into its migration tracking table before being caught and reversed.
+
 ## Documented Solutions
 
 `docs/solutions/` — solutions to past problems (bugs, best practices, patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.

--- a/app/actions/events.ts
+++ b/app/actions/events.ts
@@ -15,11 +15,15 @@ export async function logInteractionEvent(
   eventType: InteractionEventType,
   metadata: Record<string, unknown> = {}
 ): Promise<void> {
-  return _logInteractionEvent(userId, lessonSlug, eventType, metadata);
+  return _logInteractionEvent(userId, lessonSlug, eventType, metadata).catch((err) => {
+    console.error("[logInteractionEvent] server action uncaught error:", err);
+  });
 }
 
 export async function logInteractionEvents(
   events: InteractionEvent[]
 ): Promise<void> {
-  return _logInteractionEvents(events);
+  return _logInteractionEvents(events).catch((err) => {
+    console.error("[logInteractionEvents] server action uncaught error:", err);
+  });
 }

--- a/app/actions/events.ts
+++ b/app/actions/events.ts
@@ -1,0 +1,25 @@
+"use server";
+
+// Server Actions must be direct async function declarations — re-exports are not allowed.
+// These wrappers satisfy Next.js while delegating to lib/events.ts.
+
+import {
+  logInteractionEvent as _logInteractionEvent,
+  logInteractionEvents as _logInteractionEvents,
+} from "@/lib/events";
+import type { InteractionEvent, InteractionEventType } from "@/lib/events";
+
+export async function logInteractionEvent(
+  userId: string,
+  lessonSlug: string,
+  eventType: InteractionEventType,
+  metadata: Record<string, unknown> = {}
+): Promise<void> {
+  return _logInteractionEvent(userId, lessonSlug, eventType, metadata);
+}
+
+export async function logInteractionEvents(
+  events: InteractionEvent[]
+): Promise<void> {
+  return _logInteractionEvents(events);
+}

--- a/app/lesson/[slug]/page.tsx
+++ b/app/lesson/[slug]/page.tsx
@@ -51,8 +51,7 @@ export default function LessonPlayerPage() {
     streak: number;
     quizScore?: number;
     newBadges?: { slug: string; name: string; icon: string }[];
-    isFirstAttempt?: boolean;
-    bonusXp?: number;
+    firstAttemptBonus?: { bonusXp: number };
     comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number };
   }>({
     xpEarned: 0,
@@ -163,7 +162,7 @@ export default function LessonPlayerPage() {
           sfx("unlock-celebration");
           const totalXp =
             lesson.xpReward +
-            (result.bonusXp ?? 0) +
+            (result.firstAttemptBonus?.bonusXp ?? 0) +
             (result.comebackBonus?.bonusXp ?? 0);
           setUnlockData({
             xpEarned: totalXp,
@@ -171,14 +170,18 @@ export default function LessonPlayerPage() {
             streak: result.streak,
             quizScore: score,
             newBadges: result.newBadges,
-            isFirstAttempt: result.isFirstAttempt,
-            bonusXp: result.bonusXp,
+            firstAttemptBonus: result.firstAttemptBonus,
             comebackBonus: result.comebackBonus,
           });
         } catch (err) {
           console.error("[LessonPlayer] completeLesson error:", err);
-          // Still celebrate — don't punish the kid for a server error
+          // Still celebrate — show base XP so the kid isn't penalised visually for a server error
           sfx("unlock-celebration");
+          setUnlockData((prev) => ({
+            ...prev,
+            xpEarned: lesson.xpReward,
+            quizScore: score,
+          }));
         }
         setShowUnlock(true);
       });
@@ -251,8 +254,7 @@ export default function LessonPlayerPage() {
         slug={slug}
         quizScore={unlockData.quizScore}
         newBadges={unlockData.newBadges}
-        isFirstAttempt={unlockData.isFirstAttempt}
-        bonusXp={unlockData.bonusXp}
+        firstAttemptBonus={unlockData.firstAttemptBonus}
         comebackBonus={unlockData.comebackBonus}
       />
     );
@@ -298,6 +300,7 @@ export default function LessonPlayerPage() {
                       if (i < currentSection && userId) {
                         void logInteractionEvent(userId, slug, "section_replay", { sectionIndex: i });
                       }
+                      sectionStartRef.current = Date.now();
                       setCurrentSection(i);
                     }
                   }}

--- a/app/lesson/[slug]/page.tsx
+++ b/app/lesson/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   updateLessonProgress,
   completeLesson,
 } from "@/app/actions/progress";
+import { logInteractionEvent } from "@/app/actions/events";
 import { useActiveUser } from "@/lib/hooks/useActiveUser";
 import type { Lesson, LessonSection } from "@/lib/types";
 import { useAudio } from "@/lib/audio/AudioContext";
@@ -50,6 +51,9 @@ export default function LessonPlayerPage() {
     streak: number;
     quizScore?: number;
     newBadges?: { slug: string; name: string; icon: string }[];
+    isFirstAttempt?: boolean;
+    bonusXp?: number;
+    comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number };
   }>({
     xpEarned: 0,
     newLevel: 1,
@@ -59,6 +63,8 @@ export default function LessonPlayerPage() {
   const [, startTransition] = useTransition();
   // Debounce ref: prevent out-of-order sectionProgress writes from rapid navigation
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Section start time for section_time event logging
+  const sectionStartRef = useRef<number>(Date.now());
 
   // Redirect if not logged in
   useEffect(() => {
@@ -79,6 +85,7 @@ export default function LessonPlayerPage() {
     }
     setLesson(found);
 
+    sectionStartRef.current = Date.now();
     let cancelled = false;
     (async () => {
       try {
@@ -87,6 +94,10 @@ export default function LessonPlayerPage() {
         const lp = profile?.lessons[slug];
         if (lp && lp.sectionProgress > 0 && lp.status !== "completed") {
           setCurrentSection(lp.sectionProgress);
+        }
+        // Log lesson revisit (fire-and-forget, non-fatal)
+        if (lp?.status === "completed") {
+          void logInteractionEvent(userId, slug, "lesson_revisit", {});
         }
         await updateLessonProgress(userId, slug, { status: "in_progress" });
       } catch (err) {
@@ -127,12 +138,21 @@ export default function LessonPlayerPage() {
   }, [currentSection, lesson, playBGM]);
 
   const handleSectionComplete = useCallback(() => {
-    if (!lesson) return;
+    if (!lesson || !userId) return;
+    const durationMs = Date.now() - sectionStartRef.current;
+    const sec = lesson.sections[currentSection];
+    // Log section_time (fire-and-forget)
+    void logInteractionEvent(userId, slug, "section_time", {
+      sectionIndex: currentSection,
+      sectionType: sec.type,
+      durationMs,
+    });
+    sectionStartRef.current = Date.now();
     if (currentSection < lesson.sections.length - 1) {
       setCurrentSection((prev) => prev + 1);
       window.scrollTo({ top: 0, behavior: "smooth" });
     }
-  }, [lesson, currentSection]);
+  }, [lesson, currentSection, userId, slug]);
 
   const handleQuizComplete = useCallback(
     (score: number) => {
@@ -141,12 +161,19 @@ export default function LessonPlayerPage() {
         try {
           const result = await completeLesson(userId, slug, score, lesson.xpReward);
           sfx("unlock-celebration");
+          const totalXp =
+            lesson.xpReward +
+            (result.bonusXp ?? 0) +
+            (result.comebackBonus?.bonusXp ?? 0);
           setUnlockData({
-            xpEarned: lesson.xpReward,
+            xpEarned: totalXp,
             newLevel: result.level,
             streak: result.streak,
             quizScore: score,
             newBadges: result.newBadges,
+            isFirstAttempt: result.isFirstAttempt,
+            bonusXp: result.bonusXp,
+            comebackBonus: result.comebackBonus,
           });
         } catch (err) {
           console.error("[LessonPlayer] completeLesson error:", err);
@@ -157,6 +184,32 @@ export default function LessonPlayerPage() {
       });
     },
     [lesson, slug, userId, sfx]
+  );
+
+  // Callbacks for interaction event logging in quiz/boss components
+  const handleWrongAnswer = useCallback(
+    (questionIndex: number, selectedOption: string, correctOption: string) => {
+      if (!userId) return;
+      void logInteractionEvent(userId, slug, "wrong_answer", {
+        questionIndex,
+        selectedOption,
+        correctOption,
+      });
+    },
+    [userId, slug]
+  );
+
+  const handleBossAnswer = useCallback(
+    (bossHp: number, playerHp: number, questionIndex: number, wasCorrect: boolean) => {
+      if (!userId) return;
+      void logInteractionEvent(userId, slug, "boss_hp_snapshot", {
+        bossHp,
+        playerHp,
+        questionIndex,
+        wasCorrect,
+      });
+    },
+    [userId, slug]
   );
 
   // Not found
@@ -198,6 +251,9 @@ export default function LessonPlayerPage() {
         slug={slug}
         quizScore={unlockData.quizScore}
         newBadges={unlockData.newBadges}
+        isFirstAttempt={unlockData.isFirstAttempt}
+        bonusXp={unlockData.bonusXp}
+        comebackBonus={unlockData.comebackBonus}
       />
     );
   }
@@ -237,7 +293,14 @@ export default function LessonPlayerPage() {
             {lesson.sections.map((sec, i) => (
               <div key={i} className="flex items-center">
                 <button
-                  onClick={() => i <= currentSection && setCurrentSection(i)}
+                  onClick={() => {
+                    if (i <= currentSection) {
+                      if (i < currentSection && userId) {
+                        void logInteractionEvent(userId, slug, "section_replay", { sectionIndex: i });
+                      }
+                      setCurrentSection(i);
+                    }
+                  }}
                   className={`relative group`}
                   disabled={i > currentSection}
                   title={sectionLabel(sec)}
@@ -319,9 +382,15 @@ export default function LessonPlayerPage() {
                 boss={lesson.boss}
                 onComplete={handleQuizComplete}
                 onStudyUp={(idx) => setCurrentSection(idx)}
+                onWrongAnswer={handleWrongAnswer}
+                onBossAnswer={handleBossAnswer}
               />
             ) : section.type === "quiz" ? (
-              <QuizSection section={section} onComplete={handleQuizComplete} />
+              <QuizSection
+                section={section}
+                onComplete={handleQuizComplete}
+                onWrongAnswer={handleWrongAnswer}
+              />
             ) : null}
           </motion.div>
         </AnimatePresence>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -156,6 +156,34 @@ function UnlockBanner({ unlocked }: { unlocked: boolean }) {
   );
 }
 
+function ComebackBanner({ daysAway }: { daysAway: number }) {
+  const multiplier =
+    daysAway >= 14 ? "2x" : daysAway >= 7 ? "1.5x" : "1.25x";
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ delay: 0.3, duration: 0.4 }}
+      className="mb-6 p-4 rounded-lg text-center text-sm font-semibold tracking-wide"
+      style={{
+        background: "linear-gradient(135deg, rgba(249,115,22,0.12) 0%, rgba(251,191,36,0.08) 100%)",
+        border: "1px solid rgba(249,115,22,0.35)",
+        boxShadow: "0 0 16px rgba(249,115,22,0.15)",
+      }}
+    >
+      <span className="flex items-center justify-center gap-2 text-fire-orange">
+        <span>🔥</span>
+        <span>
+          Welcome back! {daysAway} day{daysAway !== 1 ? "s" : ""} away — earn{" "}
+          <span className="text-gold font-black">{multiplier} XP</span> on your next lesson!
+        </span>
+        <span>🔥</span>
+      </span>
+    </motion.div>
+  );
+}
+
 function LessonNode({
   lesson,
   progress,
@@ -408,6 +436,11 @@ export default function DashboardPage() {
 
       {/* Player Header */}
       <PlayerHeader profile={profile} onSignOut={handleSignOut} />
+
+      {/* Comeback Banner — child only, 3+ days away */}
+      {profile.role === "child" && (profile.daysAway ?? 0) >= 3 && (
+        <ComebackBanner daysAway={profile.daysAway!} />
+      )}
 
       {/* Unlock Banner */}
       <UnlockBanner unlocked={profile.unlockedToday} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import { lessons } from "@/content/lessons";
 import { loadDashboard } from "@/app/actions/progress";
 import { useActiveUser } from "@/lib/hooks/useActiveUser";
 import type { PlayerProfile, LessonProgress } from "@/lib/types";
-import { getQuizTier } from "@/lib/types";
+import { getQuizTier, getComebackMultiplier } from "@/lib/types";
 import VolumeToggle from "@/components/VolumeToggle";
 import { useAudio } from "@/lib/audio/AudioContext";
 import BadgeWall from "@/components/BadgeWall";
@@ -157,8 +157,7 @@ function UnlockBanner({ unlocked }: { unlocked: boolean }) {
 }
 
 function ComebackBanner({ daysAway }: { daysAway: number }) {
-  const multiplier =
-    daysAway >= 14 ? "2x" : daysAway >= 7 ? "1.5x" : "1.25x";
+  const multiplier = `${getComebackMultiplier(daysAway)}x`;
 
   return (
     <motion.div

--- a/components/BossBattleSection.tsx
+++ b/components/BossBattleSection.tsx
@@ -13,6 +13,8 @@ interface BossBattleProps {
   boss: BossData;
   onComplete: (score: number) => void;
   onStudyUp: (sectionIndex: number) => void;
+  onWrongAnswer?: (questionIndex: number, selectedOption: string, correctOption: string) => void;
+  onBossAnswer?: (bossHp: number, playerHp: number, questionIndex: number, wasCorrect: boolean) => void;
 }
 
 type Phase = "intro" | "battle" | "victory" | "defeat";
@@ -154,6 +156,8 @@ export default function BossBattleSection({
   boss,
   onComplete,
   onStudyUp,
+  onWrongAnswer,
+  onBossAnswer,
 }: BossBattleProps) {
   const { sfx } = useAudio();
   const reducedMotion = useReducedMotion();
@@ -248,6 +252,7 @@ export default function BossBattleSection({
         setDamageShow(boss.damagePerCorrect);
         correctCountRef.current += 1;
         setCorrectCount(correctCountRef.current);
+        onBossAnswer?.(newBossHp, playerHp, currentQ, true);
         // Delay hit VFX and advance
         safeTimeout(() => {
           setAnswerFlash(null);
@@ -265,6 +270,9 @@ export default function BossBattleSection({
         const newPlayerHp = playerHp - 1;
         setPlayerHp(newPlayerHp);
         setPlayerDamageCount((c) => c + 1);
+        const opts = question.options || ["True", "False"];
+        onWrongAnswer?.(currentQ, opts[selectedIdx] ?? String(selectedIdx), opts[correctIdx] ?? String(correctIdx));
+        onBossAnswer?.(bossHp, newPlayerHp, currentQ, false);
         // Delay boss attack VFX and advance
         safeTimeout(() => {
           setAnswerFlash(null);

--- a/components/QuizSection.tsx
+++ b/components/QuizSection.tsx
@@ -9,6 +9,7 @@ import { resolveCorrectIndex } from "@/lib/quiz-utils";
 interface QuizSectionProps {
   section: QuizSectionType;
   onComplete: (score: number) => void;
+  onWrongAnswer?: (questionIndex: number, selectedOption: string, correctOption: string) => void;
 }
 
 function QuestionCard({
@@ -16,11 +17,13 @@ function QuestionCard({
   questionNum,
   totalQuestions,
   onAnswer,
+  onWrongAnswer,
 }: {
   question: QuizQuestion;
   questionNum: number;
   totalQuestions: number;
   onAnswer: (correct: boolean) => void;
+  onWrongAnswer?: (questionIndex: number, selectedOption: string, correctOption: string) => void;
 }) {
   const { sfx } = useAudio();
   const [selected, setSelected] = useState<number | null>(null);
@@ -35,6 +38,10 @@ function QuestionCard({
     setSelected(idx);
     setRevealed(true);
     sfx(idx === correctIdx ? "correct-ding" : "wrong-buzz");
+    if (idx !== correctIdx) {
+      const opts = question.options || ["True", "False"];
+      onWrongAnswer?.(questionNum - 1, opts[idx] ?? String(idx), opts[correctIdx] ?? String(correctIdx));
+    }
   };
 
   const handleNext = () => {
@@ -288,7 +295,7 @@ function ScoreScreen({
   );
 }
 
-export default function QuizSection({ section, onComplete }: QuizSectionProps) {
+export default function QuizSection({ section, onComplete, onWrongAnswer }: QuizSectionProps) {
   const { sfx } = useAudio();
   const [currentQ, setCurrentQ] = useState(0);
   const [correctCount, setCorrectCount] = useState(0);
@@ -377,6 +384,7 @@ export default function QuizSection({ section, onComplete }: QuizSectionProps) {
               questionNum={currentQ + 1}
               totalQuestions={questions.length}
               onAnswer={handleAnswer}
+              onWrongAnswer={onWrongAnswer}
             />
           )}
         </AnimatePresence>

--- a/components/UnlockScreen.tsx
+++ b/components/UnlockScreen.tsx
@@ -17,8 +17,7 @@ interface UnlockScreenProps {
   slug: string;
   quizScore?: number;
   newBadges?: { slug: string; name: string; icon: string }[];
-  isFirstAttempt?: boolean;
-  bonusXp?: number;
+  firstAttemptBonus?: { bonusXp: number };
   comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number };
 }
 
@@ -44,7 +43,7 @@ function XPCounter({ target, duration = 2000 }: { target: number; duration?: num
   return <span>{count}</span>;
 }
 
-export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizScore, newBadges, isFirstAttempt, bonusXp, comebackBonus }: UnlockScreenProps) {
+export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizScore, newBadges, firstAttemptBonus, comebackBonus }: UnlockScreenProps) {
   const { sfx, playBGM } = useAudio();
   const reducedMotion = useReducedMotion();
   const [showContent, setShowContent] = useState(false);
@@ -220,7 +219,7 @@ export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizSco
               )}
 
               {/* First Try! bonus */}
-              {isFirstAttempt && bonusXp != null && bonusXp > 0 && (
+              {firstAttemptBonus && (
                 <motion.div
                   initial={{ scale: 0.5, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
@@ -230,7 +229,7 @@ export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizSco
                 >
                   <span className="text-gold text-sm uppercase tracking-wider font-bold">First Try!</span>
                   <div className="flex items-center gap-2">
-                    <span className="text-2xl font-black text-gold">+{bonusXp}</span>
+                    <span className="text-2xl font-black text-gold">+{firstAttemptBonus.bonusXp}</span>
                     <span className="text-gold-dim text-sm">XP</span>
                   </div>
                 </motion.div>
@@ -241,7 +240,7 @@ export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizSco
                 <motion.div
                   initial={{ scale: 0.5, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
-                  transition={{ type: "spring", stiffness: 200, delay: isFirstAttempt && bonusXp ? 0.75 : 0.6 }}
+                  transition={{ type: "spring", stiffness: 200, delay: firstAttemptBonus ? 0.75 : 0.6 }}
                   className="rpg-card px-6 py-4 flex items-center justify-between"
                   style={{ boxShadow: "0 0 20px rgba(249,115,22,0.35)", borderColor: "rgba(249,115,22,0.5)" }}
                 >
@@ -258,7 +257,7 @@ export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizSco
 
               {/* New Badges */}
               {newBadges && newBadges.length > 0 && newBadges.map((badge, i) => {
-                const bonusCardCount = (isFirstAttempt && bonusXp ? 1 : 0) + (comebackBonus ? 1 : 0);
+                const bonusCardCount = (firstAttemptBonus ? 1 : 0) + (comebackBonus ? 1 : 0);
                 return (
                   <motion.div
                     key={badge.slug}

--- a/components/UnlockScreen.tsx
+++ b/components/UnlockScreen.tsx
@@ -17,6 +17,9 @@ interface UnlockScreenProps {
   slug: string;
   quizScore?: number;
   newBadges?: { slug: string; name: string; icon: string }[];
+  isFirstAttempt?: boolean;
+  bonusXp?: number;
+  comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number };
 }
 
 function XPCounter({ target, duration = 2000 }: { target: number; duration?: number }) {
@@ -41,7 +44,7 @@ function XPCounter({ target, duration = 2000 }: { target: number; duration?: num
   return <span>{count}</span>;
 }
 
-export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizScore, newBadges }: UnlockScreenProps) {
+export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizScore, newBadges, isFirstAttempt, bonusXp, comebackBonus }: UnlockScreenProps) {
   const { sfx, playBGM } = useAudio();
   const reducedMotion = useReducedMotion();
   const [showContent, setShowContent] = useState(false);
@@ -216,23 +219,63 @@ export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizSco
                 </motion.div>
               )}
 
-              {/* New Badges */}
-              {newBadges && newBadges.length > 0 && newBadges.map((badge, i) => (
+              {/* First Try! bonus */}
+              {isFirstAttempt && bonusXp != null && bonusXp > 0 && (
                 <motion.div
-                  key={badge.slug}
                   initial={{ scale: 0.5, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
-                  transition={{ type: "spring", stiffness: 200, delay: 0.6 + i * 0.15 }}
-                  className="rpg-card px-6 py-4 flex items-center justify-between border-gold/40"
-                  style={{ boxShadow: "0 0 20px rgba(251,191,36,0.3)" }}
+                  transition={{ type: "spring", stiffness: 200, delay: 0.6 }}
+                  className="rpg-card px-6 py-4 flex items-center justify-between border-gold/60"
+                  style={{ boxShadow: "0 0 20px rgba(251,191,36,0.4)" }}
                 >
-                  <span className="text-slate-400 text-sm uppercase tracking-wider">Realm Badge</span>
+                  <span className="text-gold text-sm uppercase tracking-wider font-bold">First Try!</span>
                   <div className="flex items-center gap-2">
-                    <span className="text-2xl">{badge.icon}</span>
-                    <span className="text-gold font-bold text-sm">{badge.name}</span>
+                    <span className="text-2xl font-black text-gold">+{bonusXp}</span>
+                    <span className="text-gold-dim text-sm">XP</span>
                   </div>
                 </motion.div>
-              ))}
+              )}
+
+              {/* Welcome Back! comeback bonus */}
+              {comebackBonus && (
+                <motion.div
+                  initial={{ scale: 0.5, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  transition={{ type: "spring", stiffness: 200, delay: isFirstAttempt && bonusXp ? 0.75 : 0.6 }}
+                  className="rpg-card px-6 py-4 flex items-center justify-between"
+                  style={{ boxShadow: "0 0 20px rgba(249,115,22,0.35)", borderColor: "rgba(249,115,22,0.5)" }}
+                >
+                  <div className="flex flex-col">
+                    <span className="text-fire-orange text-sm uppercase tracking-wider font-bold">Welcome Back!</span>
+                    <span className="text-slate-500 text-xs">{comebackBonus.daysAway}d away → {comebackBonus.multiplier}x</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-2xl font-black text-fire-orange">+{comebackBonus.bonusXp}</span>
+                    <span className="text-fire-orange/60 text-sm">XP</span>
+                  </div>
+                </motion.div>
+              )}
+
+              {/* New Badges */}
+              {newBadges && newBadges.length > 0 && newBadges.map((badge, i) => {
+                const bonusCardCount = (isFirstAttempt && bonusXp ? 1 : 0) + (comebackBonus ? 1 : 0);
+                return (
+                  <motion.div
+                    key={badge.slug}
+                    initial={{ scale: 0.5, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ type: "spring", stiffness: 200, delay: 0.6 + bonusCardCount * 0.15 + i * 0.15 }}
+                    className="rpg-card px-6 py-4 flex items-center justify-between border-gold/40"
+                    style={{ boxShadow: "0 0 20px rgba(251,191,36,0.3)" }}
+                  >
+                    <span className="text-slate-400 text-sm uppercase tracking-wider">Realm Badge</span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-2xl">{badge.icon}</span>
+                      <span className="text-gold font-bold text-sm">{badge.name}</span>
+                    </div>
+                  </motion.div>
+                );
+              })}
             </motion.div>
           )}
         </AnimatePresence>

--- a/docs/plans/2026-04-04-feat-category-badges-score-tiers-badge-wall-plan.md
+++ b/docs/plans/2026-04-04-feat-category-badges-score-tiers-badge-wall-plan.md
@@ -1,0 +1,331 @@
+---
+title: "Realm Badges, Score Tiers, Badge Wall"
+type: feat
+date: 2026-04-04
+issue: "#35"
+depends_on: "#41"
+---
+
+# Realm Badges, Score Tiers, Badge Wall
+
+## Overview
+
+Make progression meaningful. Right now XP and levels are just numbers — nothing unlocks, nothing changes. This batch adds three tightly coupled features: realm badges earned by completing all lessons within a realm, bronze/silver/gold score tiers per lesson, and a visual badge wall on the dashboard.
+
+**Dependency:** Issue #41 (curriculum expansion — 36 lessons across 6 realms) must land first. It introduces the `Realm` type, `realm: number` field on `Lesson`, and `content/realms.ts`. This plan builds on that infrastructure.
+
+## Problem Statement
+
+Kids complete lessons, earn XP, see a number go up. There's no collectible reward, no visual trophy, no reason to retake a lesson they scored poorly on. The progression system has no teeth.
+
+## Proposed Solution
+
+### 1. Realm badges — earned after completing all lessons in a realm
+
+Uses the `Realm` type and `realm: number` on `Lesson` from issue #41. No new category system needed — realms ARE the badge categories.
+
+**Badge earned when ALL lessons in a realm are completed.** With 5-8 lessons per realm, this is a meaningful milestone. As more lessons are added to a realm, the bar rises naturally.
+
+**Badge definitions — derived from `content/realms.ts`:**
+
+```typescript
+// lib/badges.ts
+// Badge metadata lives alongside realm definitions — each Realm gets a badge.
+// No separate badge config needed. Badge slug = realm slug.
+
+import { realms } from "@/content/realms";
+
+export const REALM_BADGES: Record<number, {
+  name: string;
+  icon: string;
+  description: string;
+}> = {
+  1: { name: "Tower Graduate", icon: "🏰", description: "Completed The Apprentice's Tower" },
+  2: { name: "Scribe Initiate", icon: "📜", description: "Mastered The Scribe's Library" },
+  3: { name: "Frontend Forger", icon: "🌐", description: "Conquered The Frontend Realm" },
+  4: { name: "Dungeon Diver", icon: "⚔️", description: "Survived The Backend Dungeons" },
+  5: { name: "Master Artificer", icon: "🔧", description: "Graduated The Artificer's Workshop" },
+  6: { name: "Grand Champion", icon: "👑", description: "Completed The Grand Quest" },
+};
+```
+
+**Realm lesson counts (from #41):**
+
+| Realm | Name | Lessons | Badge earned after |
+|-------|------|---------|-------------------|
+| 1 | The Apprentice's Tower | 6 | 6 completions |
+| 2 | The Scribe's Library | 8 | 8 completions |
+| 3 | The Frontend Realm | 7 | 7 completions |
+| 4 | The Backend Dungeons | 7 | 7 completions |
+| 5 | The Artificer's Workshop | 5 | 5 completions |
+| 6 | The Grand Quest | 3 | 3 completions |
+
+**DB table for earned badges:**
+
+```sql
+-- supabase/migrations/005_badges.sql
+CREATE TABLE public.user_badges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  badge_slug TEXT NOT NULL,  -- realm slug, e.g., "apprentices-tower"
+  realm_id INT NOT NULL,     -- 1-6, matches Realm.id
+  earned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, badge_slug)
+);
+
+CREATE INDEX idx_user_badges_user ON public.user_badges(user_id);
+```
+
+UNIQUE constraint prevents duplicate awards. `realm_id` enables efficient queries.
+
+**Badge check logic — runs after `completeLesson()`:**
+
+```typescript
+// lib/badges.ts
+export async function checkAndAwardBadges(userId: string): Promise<string[]> {
+  // 1. Get all completed lesson slugs for user
+  // 2. Group by realm (using lesson.realm field from #41)
+  // 3. For each realm where ALL lessons are completed, check if badge exists
+  // 4. Insert missing badges
+  // 5. Return newly earned badge slugs (for celebration UI)
+}
+```
+
+### 3. Quiz score tiers — computed, not stored
+
+Score tiers are derived from the existing `lesson_progress.score` column. No schema change needed.
+
+```typescript
+// lib/types.ts
+export type QuizTier = "gold" | "silver" | "bronze" | null;
+
+export function getQuizTier(score: number | undefined): QuizTier {
+  if (score === undefined || score === null) return null;
+  if (score >= 95) return "gold";
+  if (score >= 85) return "silver";
+  if (score >= 70) return "bronze";
+  return null;
+}
+```
+
+**Display locations:**
+- Dashboard lesson nodes (`app/page.tsx` LessonNode) — medal icon next to completed lessons
+- Parent child detail page (`app/parent/[childId]/page.tsx`) — tier shown per lesson
+- Unlock screen (`components/UnlockScreen.tsx`) — tier announcement on completion
+
+**Tier visuals:**
+
+| Tier | Icon | Color |
+|---|---|---|
+| Gold | 🥇 | `text-gold` |
+| Silver | 🥈 | `text-slate-300` |
+| Bronze | 🥉 | `text-fire-orange` |
+| None (<70%) | — | — |
+
+### 4. Badge wall — new dashboard section
+
+New component inserted between UnlockBanner and Quest Map on the kid dashboard.
+
+```
+┌──────────────────────────────────────────┐
+│  PlayerHeader (existing)                 │
+├──────────────────────────────────────────┤
+│  UnlockBanner (existing)                 │
+├──────────────────────────────────────────┤
+│  ┌─ Realm Badges ─────────────────────┐  │
+│  │  🏰      📜      🌐      ⚔️      🔧      👑  │  │
+│  │  Tower  Scribe  Front  Dung  Artif Grand │  │
+│  │  ✓      3/8     🔒     🔒     🔒     🔒  │  │
+│  │                                        │  │
+│  │  "1 of 6 realm badges earned"          │  │
+│  └────────────────────────────────────────┘  │
+├──────────────────────────────────────────┤
+│  Quest Map (existing)                    │
+└──────────────────────────────────────────┘
+```
+
+**Component: `components/BadgeWall.tsx`**
+
+- Grid of 6 badge slots (one per realm, uses `content/realms.ts` + `REALM_BADGES`)
+- Earned: glowing icon + realm name + accent color glow, `rpg-card-completed` style
+- Unearned: greyed out icon + "X/Y" progress count, `rpg-card-locked` style
+- Realm accent colors from #41 (emerald, amber, sky, violet, rose, gold)
+- Summary: "X of 6 realm badges earned" at bottom
+- Animation: staggered entrance, glow pulse on earned badges
+- Tap earned badge → tooltip with badge name + description + date earned
+- Tap unearned badge → shows which lessons remain
+
+**Parent view:** Badge wall also shown on child detail page (`app/parent/[childId]/page.tsx`), same component, read-only.
+
+## Technical Approach
+
+### Phase 0: Types + Migration
+
+**Prerequisite:** #41 must be merged — provides `Realm` type, `realm: number` on Lesson, `content/realms.ts`.
+
+**Files to modify:**
+- `lib/types.ts` — add `QuizTier`, `getQuizTier()`, `Badge` type, add `badges` to `PlayerProfile`
+- `supabase/migrations/005_badges.sql` — `user_badges` table + fix `xp_transactions` CHECK constraint
+
+### Phase 1: Server Logic
+
+**Files to modify:**
+- `lib/badges.ts` (new) — `REALM_BADGES` config, `checkAndAwardBadges()`, `getBadgesForUser()`
+- `lib/progress.ts` — update `completeLesson()` to call `checkAndAwardBadges()`, update `rowsToProfile()` to include badges, update `loadDashboard()` to fetch badges
+- `app/actions/progress.ts` — expose badge data through existing server actions
+- `app/actions/users.ts` — update `listChildren()` and `getChildProfileForParent()` to include badges
+
+### Phase 2: Components (parallelizable)
+
+**Files to create:**
+- `components/BadgeWall.tsx` — badge grid component
+- `components/QuizTierBadge.tsx` — small medal icon component
+
+**Files to modify:**
+- `app/page.tsx` — insert BadgeWall, add tier icons to LessonNode
+- `app/parent/[childId]/page.tsx` — insert BadgeWall, add tier to lesson rows
+- `components/UnlockScreen.tsx` — show tier earned + new badge earned if applicable
+- `components/QuizSection.tsx` — show tier on score screen
+
+### Phase 3: Integration + Polish
+
+- Wire badge earn celebration into unlock screen (newly earned badge pops in)
+- Audio: use `unlock-celebration` SFX for badge earn
+- Animation: immediate state change, 600ms delayed VFX (per learnings doc)
+- AnimatePresence with dynamic keys (per learnings doc)
+
+## Acceptance Criteria
+
+### Functional
+- [ ] `user_badges` table created via migration 005
+- [ ] Completing all lessons in a realm auto-awards the realm badge
+- [ ] Badge wall visible on kid dashboard between UnlockBanner and Quest Map
+- [ ] Badge wall shows earned/unearned state for all 6 realms with realm accent colors
+- [ ] Tapping an earned badge shows badge name, description, date earned
+- [ ] Unearned badges show progress ("4 of 6 lessons" remaining)
+- [ ] Quiz score tiers (bronze/silver/gold) displayed on completed lesson nodes
+- [ ] Score tiers visible on parent child detail page
+- [ ] Unlock screen announces tier earned on lesson completion
+- [ ] Unlock screen announces new badge earned (if any)
+- [ ] Badge persists through parent lesson resets (never revoked)
+
+### Non-Functional
+- [ ] Badge check adds <50ms to lesson completion flow
+- [ ] Badge wall renders without layout shift on dashboard load
+- [ ] Animations respect `prefers-reduced-motion`
+- [ ] Mobile responsive — badge grid wraps cleanly on small screens
+
+## Spec-Flow Findings (Critical)
+
+### 1. Score tier thresholds adjusted for variable quiz sizes
+
+Current quizzes have 5 questions (scores: 0/20/40/60/80/100%). Issue #41 introduces boss difficulty scaling: 5 questions (Realm 1-2), 6 (Realm 3-4), 7 (Realm 5-6). With 6 questions, possible scores include 83% and 67%. With 7: 71%, 86%, 100%.
+
+**Decision:** Use thresholds that work across all quiz sizes:
+
+```typescript
+export function getQuizTier(score: number | undefined): QuizTier {
+  if (score === undefined || score === null) return null;
+  if (score >= 100) return "gold";   // perfect score
+  if (score >= 80) return "silver";  // 4/5, 5/6, 6/7
+  if (score >= 60) return "bronze";  // 3/5, 4/6, 5/7
+  return null;
+}
+```
+
+Gold = perfection (any quiz size). Silver/Bronze achievable at all sizes.
+
+### 2. XP clawback is silently broken (pre-existing bug)
+
+`xp_transactions` has `CHECK (amount > 0)` (migration 001, line 53). The `resetLessonProgress` function calls `award_xp` with a negative amount — this silently fails. Migration 005 should fix this:
+
+```sql
+ALTER TABLE public.xp_transactions DROP CONSTRAINT xp_transactions_amount_check;
+ALTER TABLE public.xp_transactions ADD CHECK (amount != 0);
+```
+
+### 3. Badge revocation on parent reset
+
+**Decision: Badges persist.** Never take away something a kid earned. If a parent resets a lesson, the badge stays. This is kid-friendly and avoids punishment psychology. The badge was legitimately earned — the reset is for learning reinforcement, not punishment.
+
+### 4. Badge-earn celebration on unlock screen
+
+Extend `LessonCompletionResult` to include `newBadges?: { slug: string; name: string; icon: string }[]`. UnlockScreen shows badge pop-in after XP/level/streak when a new badge is earned.
+
+### 5. Badge wall for zero-progress users
+
+Show the wall with all badges locked + motivational message: "Complete lessons to earn badges!" Gives them something to aim for.
+
+### 6. Progress denominator is dynamic
+
+"4/6 lessons" counts from current content files for that realm. When new lessons are added to a realm, the denominator grows. Badge earned = all lessons in realm complete.
+
+## Edge Cases
+
+- **Realm not fully populated yet:** If only 3 of 8 planned Realm 2 lessons exist in content, badge is earned after completing those 3. When more are added, badge persists (grandfathered).
+- **Kid completes lesson with <60% score:** No tier shown, lesson still counts as completed for badge progress.
+- **Kid retakes lesson and gets higher score:** Tier upgrades automatically (computed from current score in lesson_progress).
+- **Kid retakes lesson and gets lower score:** Tier downgrades (reflects current score, not best-ever). This is fine — the reset was intentional.
+- **Parent views badge wall for kid:** Read-only, same component.
+- **Brand-new user, no progress:** Badge wall visible but all locked, with motivational message.
+
+## Dependencies & Risks
+
+- **Bug fix required:** `CHECK (amount > 0)` on `xp_transactions` must be relaxed in migration 005 to unblock XP clawback on lesson reset (pre-existing bug).
+- **Risk:** During content rollout, realms with few lessons make badges too easy. Mitigated by: (a) grandfathering early earners, (b) badge wall shows realm lesson count so it's transparent.
+- **Note:** Per memory, user wants Prisma eventually — keep supabase additions minimal. One simple table, one simple query. Easy to migrate later.
+
+## ERD
+
+```mermaid
+erDiagram
+    users ||--o{ user_badges : earns
+    users ||--o{ lesson_progress : tracks
+
+    users {
+        uuid id PK
+        text email
+        text hero_name
+        text hero_class
+        text role
+        uuid parent_id FK
+    }
+
+    user_badges {
+        uuid id PK
+        uuid user_id FK
+        text badge_slug
+        timestamptz earned_at
+    }
+
+    lesson_progress {
+        uuid user_id FK
+        text lesson_slug
+        text status
+        int score
+        int xp_earned
+        int attempts
+        timestamptz completed_at
+    }
+```
+
+## References
+
+### Internal
+- Dashboard layout: `app/page.tsx:407-410` (badge wall insertion point)
+- Lesson types: `lib/types.ts:119-129` (Lesson interface)
+- Profile types: `lib/types.ts:145-159` (PlayerProfile)
+- Score storage: `lib/progress.ts:168-169` (score written on completion)
+- Completion flow: `lib/progress.ts:160-207` (completeLesson)
+- Dashboard load: `lib/progress.ts:294-299` (loadDashboard)
+- Award XP pattern: `supabase/migrations/004_fixes.sql:21-70` (partial index pattern)
+- Parent reset: `app/actions/users.ts:218-271` (resetLessonProgress)
+- RPG CSS: `app/globals.css:7-36` (color tokens), `193-221` (rpg-card)
+- Animation pattern: `docs/solutions/ui-bugs/boss-battle-hp-desynced-from-answer-flash.md`
+- AnimatePresence keys: `docs/solutions/ui-bugs/animate-presence-boolean-toggle-no-retrigger.md`
+
+### Related Issues
+- #35 (this batch)
+- #41 (prerequisite — curriculum expansion, 36 lessons, 6 realms, Realm type)
+- #36 (Batch 2 — interaction logging, depends on this foundation)
+- #38 (Batch 4 — realm mastery stars, extends badge system)

--- a/docs/plans/2026-04-04-feat-curriculum-expansion-32-lessons-plan.md
+++ b/docs/plans/2026-04-04-feat-curriculum-expansion-32-lessons-plan.md
@@ -1,0 +1,548 @@
+---
+title: "feat: Curriculum Expansion — 36 Lessons Across 6 Realms"
+type: feat
+date: 2026-04-04
+deepened: 2026-04-04
+---
+
+# Curriculum Expansion — 36 Lessons Across 6 Realms
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-04
+**Research agents used:** 6 (gamification best practices, quest map UI, architecture review, learnings check, code sandbox, simplicity review)
+
+### Key Improvements
+1. **Simplified phasing** — 3 phases instead of 6. Ship lessons immediately with minimal infrastructure.
+2. **First-class Realm type** — separate `Realm` entity instead of flat fields on Lesson. Prevents data duplication.
+3. **Generic BossShell** — extract shared animation wrapper; use generic boss + 5-6 custom sprites instead of 29 hand-crafted SVGs.
+4. **Sandpack for practicals** — Sandpack (editor + execution + preview, ~200KB, Apache-2.0) + CodeMirror readonly-ranges for fill-in-the-blank.
+5. **XP scaling per realm** — rewards grow with difficulty (50→75→100→125→150→175 per realm).
+6. **Boss difficulty scaling** — 5 questions (Realm 1-2), 6 (Realm 3-4), 7 (Realm 5-6).
+7. **Winding quest map** — Duolingo-style serpentine vertical path with realm gates.
+
+### Critical Learnings to Follow (from docs/solutions/)
+- Phase 0 (types) → Phase 1 (parallel content) → Phase 2 (registration). Never parallelize shared index file edits.
+- FillBlank validation: template `___` count must equal `blanks.length` must equal `solution` keys. TypeScript can't enforce this.
+- Never use `startTransition` with Server Actions inside `useEffect` — causes infinite re-render loop. Use plain async IIFE + cancelled flag.
+- React 19: `useRef()` without initial value errors. Always `useRef<T>(undefined)`.
+- Boss animations: use counter-as-key pattern for repeatable animations, not boolean toggles.
+- Separate state updates (HP, XP) from VFX (sprites, shake). Apply state immediately, cosmetics with delay.
+
+---
+
+## Overview
+
+Expand KidKode from 7 lessons to 36, organized into 6 themed realms with hands-on "practicals" sprinkled throughout. Target: ages 10-15, may know Scratch/block-code. Reorder existing lessons, add 29 new lessons from programming fundamentals through full-stack concepts.
+
+Related: issue #27 (30+ lessons), plan at `.claude/plans/synthetic-hatching-frog.md` (original curriculum map).
+
+## Resolved Decisions
+
+All blocking questions answered:
+
+| Decision | Answer |
+|----------|--------|
+| Hello World lesson | YES — add as Lesson 7, 33+ total |
+| Realm 4 reorder | YES — JSON → Async → APIs → DBs → Auth |
+| Practicals | YES — add applied mini-projects after every 3-4 theory lessons, across ALL realms |
+| Locking model | Linear within realm, jump between unlocked realms (FF7-style) |
+| Realm UI | Full-screen transition (2-3s, skippable) on first realm entry |
+| Scratch reference | Name Scratch explicitly with fallback: "If you've used Scratch (or any block-coding tool)..." |
+| Capstone length | More sections (8 instead of 4), same lesson — finer checkpointing |
+| Early debugging | Fold error-reading basics into Loops lesson; keep Lesson 29 for DevTools/breakpoints |
+| Code sandbox | Write content assuming future sandbox; use fill-blank for now |
+
+---
+
+## Critical Fixes to Original Plan
+
+SpecFlow analysis identified 3 blocking issues in the original curriculum map:
+
+### Fix 1: Missing "Hello World" Lesson
+
+**Problem:** Realm 2 starts with Variables (Lesson 7) but the child has never run a line of code. They don't know `console.log`, the edit-save-run cycle, or where output appears.
+
+**Fix:** Insert **Lesson 7: "Hello World: Your First Spell"** between Realm 1 (tools) and Realm 2 (fundamentals). Teaches: create a `.js` file, run with `node`, `console.log()`, edit-save-run cycle, comments.
+
+This bumps total to **33 lessons** and shifts Realm 2 numbering by 1.
+
+### Fix 2: Realm 4 Sequencing Error
+
+**Problem:** APIs lesson (20) uses `fetch()` which requires async/await, but async/await isn't taught until lesson 23. JSON lesson (21) comes after APIs but is required during APIs.
+
+**Fix — corrected Realm 4 order:**
+
+| # | Title | Rationale |
+|---|-------|-----------|
+| 20 | Client vs Server *(existing)* | What is a request? |
+| 21 | JSON: The Universal Scroll Language | Data format — needed before fetch |
+| 22 | Sync vs Async: Time Magic *(existing)* | Promises/await — needed before fetch |
+| 23 | APIs: The Messenger Ravens | Now has JSON + async prereqs |
+| 24 | Databases *(existing)* | CRUD on server side |
+| 25 | Authentication: The Gatekeeper's Key | Depends on all above |
+
+### Fix 3: Lesson 6 Missing Boss
+
+**Problem:** Git Branches is the only lesson without a boss. Breaks the reward pattern.
+
+**Fix:** Add boss: **"The Detached HEAD Phantom"** — plays on the common `detached HEAD` git state.
+
+---
+
+## Final Curriculum — 6 Realms, 36 Lessons (including 3 Practicals)
+
+*Practicals are hands-on applied mini-projects that break up theory streaks. Marked with (P).*
+
+### REALM 1: The Apprentice's Tower (Orientation & Tools) — 6 lessons
+
+| # | Title | Status | XP | Boss |
+|---|-------|--------|-----|------|
+| 1 | The Adventurer's Map: What is Code? | NEW | 50 | The Block Golem |
+| 2 | Terminal: The Dungeon Console | EXISTING (was #3) | 60 | Permission Denied Golem |
+| 3 | Terminal II: Spells & Shortcuts | NEW | 70 | The Wildcard Wraith |
+| 4 | The Code Forge: Your First Editor | NEW | 80 | The Extension Mimic |
+| 5 | Git: Save Points for Your Code | EXISTING (was #1) | 90 | Merge Conflict Hydra |
+| 6 | Git Branches: Parallel Universes | EXISTING (was #2) | 100 | The Detached HEAD Phantom |
+
+### REALM 2: The Scribe's Library (Programming Fundamentals) — 8 lessons
+
+| # | Title | Status | XP | Boss |
+|---|-------|--------|-----|------|
+| 7 | Hello World: Your First Spell | NEW | 80 | The Silent Console |
+| 8 | Variables: Naming Your Potions | NEW | 90 | The Unnamed Specter |
+| 9 | Conditions: The Crossroads | NEW | 100 | The Riddle Sphinx |
+| 10 | Loops: The Enchanted Treadmill | NEW | 110 | The Infinite Loop Worm |
+| 11 | Functions: Bottling Your Spells | NEW | 120 | The Copy-Paste Slime |
+| 12 | **(P) The Gauntlet: Console Quest** | NEW | 150 | The Logic Gargoyle |
+| 13 | Arrays: The Treasure Chest | NEW | 130 | The Index Troll |
+| 14 | Objects: The Character Sheet | NEW | 140 | The Shapeless Ooze |
+
+*Practical 12 — apply variables, conditions, loops, functions in a guided console-based text adventure or calculator. No new concepts, pure application.*
+
+### REALM 3: The Frontend Realm (Building What You See) — 7 lessons
+
+| # | Title | Status | XP | Boss |
+|---|-------|--------|-----|------|
+| 15 | HTML: The Skeleton Scroll | NEW | 120 | The Tag Lich |
+| 16 | CSS: The Enchantment Layer | NEW | 130 | The Style Vampire |
+| 17 | Layout: The Architect's Grid | NEW | 140 | The Chaos Architect |
+| 18 | JavaScript in the Browser: The Puppet Strings | NEW | 150 | The Static Gargoyle |
+| 19 | **(P) The Forge: Build a Fan Page** | NEW | 180 | The Pixel Perfectionist |
+| 20 | Forms & Input: The Questionnaire Golem | NEW | 160 | The Questionnaire Golem |
+| 21 | Responsive Design: The Shapeshifter's Cloak | NEW | 170 | The Shapeshifter |
+
+*Practical 19 — combine HTML + CSS + DOM JS to build a simple fan page (favorite game/show). Apply layout, styling, and interactivity together.*
+
+### REALM 4: The Backend Dungeons (The Invisible Kingdom) — 7 lessons
+
+| # | Title | Status | XP | Boss |
+|---|-------|--------|-----|------|
+| 22 | Client vs Server: The Two Kingdoms | EXISTING (was #4) | 150 | The 404 Phantom |
+| 23 | JSON: The Universal Scroll Language | NEW | 160 | The Syntax Gremlin |
+| 24 | Sync vs Async: Time Magic | EXISTING (was #6) | 170 | The Callback Serpent |
+| 25 | APIs: The Messenger Ravens | NEW | 180 | The Raven Interceptor |
+| 26 | **(P) The Workshop: Weather Dashboard** | NEW | 200 | The API Hydra |
+| 27 | Databases: The Inventory System | EXISTING (was #5) | 190 | The Null Pointer |
+| 28 | Authentication: The Gatekeeper's Key | NEW | 200 | The Identity Thief |
+
+*Practical 26 — fetch real weather data from a public API, parse JSON, display it. Combines client/server, JSON, async, and APIs in one applied project.*
+
+### REALM 5: The Artificer's Workshop (Real Tools & Workflows) — 5 lessons
+
+| # | Title | Status | XP | Boss |
+|---|-------|--------|-----|------|
+| 29 | Asking AI: The Genie's Rules | EXISTING (was #7) | 180 | The Hallucination Phantom |
+| 30 | Claude Code: The AI Familiar | NEW | 200 | Hallucination Phantom II |
+| 31 | npm & Packages: The Potion Shop | NEW | 200 | The Dependency Dragon |
+| 32 | Debugging: The Bug Exterminator | NEW | 220 | The Bug Swarm |
+| 33 | Deployment: Launching the Airship | NEW | 240 | The Build Failure Demon |
+
+### REALM 6: The Grand Quest (Putting It All Together) — 3 lessons
+
+| # | Title | Status | XP | Boss |
+|---|-------|--------|-----|------|
+| 34 | Project Planning: The Architect's Blueprint | NEW | 200 | The Scope Creep Hydra |
+| 35 | Build a Profile Page: The Hero's Banner | NEW | 250 | The Blank Page Dragon |
+| 36 | The Final Boss: Full Stack Siege | NEW | 300 | The Chaos Compiler |
+
+**Total XP: 5,280** (completionist at 1.0x) / **~7,920** (perfect at 1.5x first-attempt bonus)
+
+### Summary
+
+| | Existing | New | Practicals | Total |
+|---|---------|-----|-----------|-------|
+| Realm 1 | 3 | 3 | 0 | 6 |
+| Realm 2 | 0 | 7+1 | 1 | 8 |
+| Realm 3 | 0 | 6+1 | 1 | 7 |
+| Realm 4 | 3 | 3+1 | 1 | 7 |
+| Realm 5 | 1 | 4 | 0 | 5 |
+| Realm 6 | 0 | 3 | 0 | 3 |
+| **Total** | **7** | **28+3** | **3** | **36** |
+
+---
+
+## XP & Level System Changes
+
+Current `XP_PER_LEVEL` only goes to level 10 (3200 XP). Extend to 15 levels with continued quadratic curve:
+
+```
+XP_PER_LEVEL = [0, 100, 250, 450, 700, 1000, 1400, 1900, 2500, 3200, 4000, 4900, 5900, 7000, 8500]
+```
+
+Level 10 (~lesson 24) = "graduated basics." Level 15 = completionist/perfectionist.
+
+**Note:** `calculateLevel()` already handles overflow gracefully (`+ 500` fallback at line 209). Extending the array is a nice-to-have, not a blocker. Can ship lessons before extending.
+
+---
+
+## Infrastructure Changes Required
+
+### 1. First-class Realm type (not flat fields on Lesson)
+
+**Why:** `realmName` as a flat string on every lesson = denormalized data. Realm-level data will grow (colors, transitions, badges, unlock conditions). A separate entity is the right abstraction.
+
+```typescript
+// lib/types.ts — NEW
+export interface Realm {
+  id: number;             // 1-6
+  slug: string;           // "apprentices-tower"
+  name: string;           // "The Apprentice's Tower"
+  subtitle: string;       // "Orientation & Tools"
+  icon: string;           // emoji
+  accentColor: string;    // Tailwind token, e.g. "emerald-500"
+  unlockCondition: RealmUnlockCondition;
+}
+
+export type RealmUnlockCondition =
+  | { type: "default" }                          // realm 1, always open
+  | { type: "realm-complete"; realmId: number }  // complete prior realm
+  | { type: "all-realms"; realmIds: number[] };  // realm 6
+
+// On Lesson — add only the foreign key:
+export interface Lesson {
+  // ... existing fields
+  realm: number;  // references Realm.id
+}
+```
+
+Create `content/realms.ts` with realm definitions. Derive `realmName` at render time via lookup.
+
+**Realm color tokens:**
+
+| Realm | Theme | Accent |
+|---|---|---|
+| 1: Apprentice's Tower | Tools & orientation | `emerald-500` |
+| 2: Scribe's Library | JS fundamentals | `amber-500` |
+| 3: Frontend Realm | HTML/CSS/DOM | `sky-500` |
+| 4: Backend Dungeons | Server/APIs/DB | `violet-500` |
+| 5: Artificer's Workshop | AI, npm, deploy | `rose-500` |
+| 6: Grand Quest | Capstone | `gold` |
+
+### 2. Extract unlock logic to `lib/unlock.ts`
+
+**Why:** `unlockNextLesson` is duplicated in `lib/progress.ts` and `app/actions/users.ts` with identical sort-and-find logic. Adding realm awareness multiplies the duplication cost.
+
+```typescript
+// lib/unlock.ts — pure functions, no DB calls, testable
+export function getNextUnlockableSlugs(
+  completedSlug: string,
+  allLessons: Lesson[],
+  allRealms: Realm[],
+  completedSlugs: Set<string>
+): string[];
+
+export function isRealmComplete(realmId: number, allLessons: Lesson[], completedSlugs: Set<string>): boolean;
+
+export function getFirstLessonSlug(allLessons: Lesson[]): string;
+```
+
+Both `progress.ts` and `users.ts` delegate to these. Kills the duplication.
+
+### 3. Export lightweight `lessonMetas` for client bundle
+
+**Why:** `app/page.tsx` imports the full `lessons` array (all section content, quiz questions, slides). At 36 lessons, this could push 200KB+ of JSON into the client. The dashboard only uses 6 fields per lesson.
+
+```typescript
+// content/lessons/index.ts — NEW export
+export type LessonMeta = Pick<Lesson, 'slug' | 'title' | 'description' | 'order' | 'realm' | 'xpReward' | 'estimatedMinutes' | 'icon'>;
+
+export const lessonMetas: LessonMeta[] = lessons.map(({ slug, title, description, order, realm, xpReward, estimatedMinutes, icon }) => ({
+  slug, title, description, order, realm, xpReward, estimatedMinutes, icon,
+}));
+```
+
+Dashboard pages import `lessonMetas`. Full `lessons` array stays server-only.
+
+### 4. Renumber existing lesson `order` fields (no file renames)
+
+**Don't rename files.** The numeric prefix is cosmetic — `order` field is the source of truth. Renaming breaks `git blame` and creates needless churn.
+
+| Lesson Slug | Current Order | New Order | File (unchanged) |
+|-------------|--------------|-----------|-------------------|
+| terminal-basics | 3 | 2 | `03-terminal-basics.ts` |
+| git-save-points | 1 | 5 | `01-git-save-points.ts` |
+| git-branches | 2 | 6 | `02-git-branches.ts` |
+| client-vs-server | 4 | 22 | `04-client-vs-server.ts` |
+| sync-vs-async | 6 | 24 | `06-sync-vs-async.ts` |
+| databases | 5 | 27 | `05-databases.ts` |
+| asking-ai | 7 | 29 | `07-asking-ai.ts` |
+
+New lessons use `{NN}-{slug}.ts` starting at `08-*`. The `NN` prefix aids directory listing but is not authoritative.
+
+**Migration note:** `lesson_progress` uses `lesson_slug` (not order), so progress data is safe.
+
+### 5. Boss sprite architecture: BossShell + generic fallback
+
+**Why:** 29 hand-crafted SVG sprites (~7,000 lines of SVG art) is unsustainable. Current sprites share identical animation logic (Framer Motion state machine, `BossSpriteProps`).
+
+**Approach:**
+
+```
+components/bosses/
+  BossShell.tsx          — shared animation wrapper (motion.div, state classes, damage flash)
+  GenericBoss.tsx         — parametric boss: takes color/emoji/shape config, renders a stylized creature
+  sprites/               — custom SVGs for milestone bosses only
+    hydra.tsx            — just SVG innards, no animation logic
+    golem.tsx
+    ...                  — 5-6 total custom sprites (one per realm final boss)
+  index.ts               — registry with fallback to GenericBoss
+```
+
+`BossShell.tsx` handles all Framer Motion animation. Each sprite is stateless SVG-only. `GenericBoss` takes a config object (primary color, shape variant, size) and renders a parameterized creature.
+
+**Registry with fallback:**
+```typescript
+export function getBossSprite(key: string): ComponentType<BossSpriteProps> {
+  return bossSprites[key] ?? GenericBoss;
+}
+```
+
+### 6. Early debugging in Loops lesson
+
+Fold basic error-reading into Lesson 10 (Loops) — where kids first encounter infinite loops. Cover: `Ctrl+C`, reading error messages, common mistakes. Lesson 32 (Debugging) covers advanced topics (DevTools, breakpoints, stack traces).
+
+### 7. Unlock logic (realm-based)
+
+Implemented in `lib/unlock.ts` (see item 2 above):
+- Linear progression within a realm
+- Completing a realm's last lesson unlocks next realm
+- Can revisit any lesson in any unlocked realm
+- Realm 6 requires all prior realms completed
+
+**Note:** Current linear unlock already works for shipping lessons immediately. Realm-based locking is a Phase 3 enhancement — the ordering alone handles progression correctly.
+
+### 8. Organize lesson files by realm (filesystem)
+
+```
+content/lessons/
+  realm-1/   01-adventurers-map.ts ... 06-git-branches.ts
+  realm-2/   07-hello-world.ts ... 14-objects.ts
+  realm-3/   15-html.ts ... 21-responsive.ts
+  realm-4/   22-client-server.ts ... 28-auth.ts
+  realm-5/   29-asking-ai.ts ... 33-deployment.ts
+  realm-6/   34-project-planning.ts ... 36-final-boss.ts
+  index.ts   (barrel file, flat lessons array — consumers see no change)
+```
+
+---
+
+## Implementation Phases (Simplified: 3 not 6)
+
+The simplicity review found that the original 6-phase plan front-loads infrastructure that isn't needed to start shipping lessons. The current linear unlock system handles 36 lessons identically to 7. Ship content first, polish later.
+
+### Phase 1: Minimal Infrastructure (~1 day)
+
+**Minimum changes to start adding lessons:**
+
+- [ ] Add `realm: number` to `Lesson` interface in `lib/types.ts`
+- [ ] Create `Realm` type and `content/realms.ts` with 6 realm definitions
+- [ ] Extend `XP_PER_LEVEL` to 15 levels (one line change)
+- [ ] Update `order` values on 7 existing lesson files (no file renames)
+- [ ] Add `realm` field to existing lessons
+- [ ] Create `content/lessons/realm-*/` directories
+- [ ] Update `content/lessons/index.ts` imports
+- [ ] Extract `BossShell.tsx` from existing sprite components
+- [ ] Create `GenericBoss.tsx` with parametric rendering + fallback registry
+- [ ] Add boss data to Lesson 6 (Git Branches): The Detached HEAD Phantom
+
+**Defer to Phase 3:** Realm-based unlock logic, `lessonMetas` export, `lib/unlock.ts` extraction. Current linear unlock works fine.
+
+### Phase 2: Content (ongoing, ship incrementally)
+
+Write lessons in curriculum order, one at a time. Ship every 3-5 lessons. The flat quest map handles it.
+
+**Execution pattern (from `docs/solutions/feature-patterns/adding-lessons-and-step-types.md`):**
+1. Write lesson content file (`content/lessons/realm-N/NN-slug.ts`)
+2. Add import + array entry in `content/lessons/index.ts`
+3. Boss uses `GenericBoss` fallback (no custom sprite needed)
+4. Run `tsc --noEmit` to verify
+5. Ship
+
+**Content priority order:**
+1. Realm 1 & 2 (Lessons 1, 3, 4, 7-14) — 11 new, foundation
+2. Realm 3 (Lessons 15-21) — 7 new, frontend
+3. Realm 4 (Lessons 23, 25, 26, 28) — 4 new, backend
+4. Realm 5 & 6 (Lessons 30-36) — 7 new, tools + capstone
+
+### Phase 3: Polish (when 15+ lessons are live)
+
+- [ ] Realm-based unlock logic (`lib/unlock.ts`)
+- [ ] `lessonMetas` lightweight export for client bundle
+- [ ] Quest map UI: realm groupings, winding path, gates
+- [ ] Full-screen realm transition animations
+- [ ] 5-6 custom boss sprites for realm-final bosses
+- [ ] Boss difficulty scaling (5→6→7 questions by realm)
+- [ ] Session-based gentle streaks
+- [ ] Realm completion badges
+
+---
+
+## Open Items (non-blocking)
+
+1. **Code sandbox** — Sandpack recommended (see research below). Write content assuming future sandbox; use fill-blank for now.
+2. **Capstone lesson (36)** — 8 sections instead of 4 for finer checkpointing. Exact section breakdown TBD during content writing.
+3. **Practical themes** — current suggestions (Console Quest, Fan Page, Weather Dashboard) are placeholders. Finalize during outline phase.
+
+---
+
+## Research Insights
+
+### XP & Progression Design
+
+**Current quadratic curve is correct.** Deltas grow linearly (100, 150, 200...) — this is the consensus approach for educational games with bounded content. Codecademy, Duolingo, and Prodigy all use variants of this.
+
+**Scale XP rewards per realm** to match difficulty:
+
+| Realm | Base XP per lesson | Practical XP | Rationale |
+|-------|-------------------|--------------|-----------|
+| 1 | 50-100 | — | Easy orientation |
+| 2 | 80-150 | 150 | First real coding |
+| 3 | 120-170 | 180 | Applied frontend |
+| 4 | 150-200 | 200 | Abstract backend |
+| 5 | 180-240 | — | Professional tools |
+| 6 | 200-300 | — | Capstone |
+
+**Boss victory bonus:** +50 XP per boss kill (on top of lesson XP). Incentivizes completing the battle, not just passing the quiz.
+
+**Level-up pacing:** Target a level-up every 2-3 lessons in early realms, every 3-4 in later realms. Test by simulating a play-through and counting sessions-between-levels.
+
+**Note:** `calculateLevel()` in `lib/types.ts` already handles overflow gracefully (line 209: `+ 500` fallback). The 15-level extension is future-proofing but not strictly required — the current 10-level array works with auto-generated thresholds.
+
+### Boss Battle Scaling
+
+| Realm | Questions | Player HP | Boss HP | Pass Threshold |
+|-------|-----------|-----------|---------|---------------|
+| 1-2 | 5 | 4 hearts | 100 | 60% (3/5) |
+| 3-4 | 6 | 3 hearts | 120 | 67% (4/6) |
+| 5-6 | 7 | 3 hearts | 140 | 71% (5/7) |
+
+**Partial credit:** After wrong answer, show explanation + simpler follow-up for half damage. Mirrors classroom "Boss Fight Assessment" research.
+
+**Retry improvements:** Shuffle questions on retry (prevent memorizing positions). After 2 failed attempts, offer one-time hint per question.
+
+**Add `tauntText`** to `BossData` — boss says something before battle. Already have `defeatText` for victory.
+
+### Engagement: Gentle Streaks
+
+Session-based, not day-based (kid may only play 3 days/week):
+
+| Feature | Design |
+|---------|--------|
+| Streak unit | "Sessions" not "days" |
+| Streak freeze | Auto-grant 1/week |
+| Broken streak | "Comeback bonus" — 2x XP on return |
+| Milestones | 3, 7, 14, 30 sessions |
+| Visual | Warm glow, not angry fire |
+
+### Practical Lesson Design
+
+**Scaffolding progression across realms:**
+
+| Realm | Structure | Tasks | Duration |
+|-------|-----------|-------|----------|
+| 1-2 | 100% guided, step-by-step | 3 | ~12 min |
+| 3-4 | 70% scaffolded / 30% open | 4 | ~18 min |
+| 5-6 | 50% scaffolded / 50% open | 5 | ~25 min |
+
+**Practical structure:**
+1. Context (1-2 min): "You're building X for Y reason"
+2. Starter code: 60-70% complete with `// TODO` markers
+3. 3-5 tasks: each applies one concept from recent lessons
+4. Validation: automated checks (existing interactive step types)
+5. Bonus challenge (optional, +50% XP)
+
+### Quest Map UI (Phase 3)
+
+**Layout: Winding vertical path** (Duolingo-style serpentine):
+```tsx
+// Repeating offset pattern
+const OFFSETS = [0, -60, -100, -60, 0, 60, 100, 60]; // px from center
+// Responsive: mobile uses tighter offsets (30/50), desktop uses wider (60/100)
+```
+
+**Realm gates** between sections: locked/unlocked visual divider. Gate animates open when previous realm is complete.
+
+**Animation fix:** Current stagger `delay: index * 0.12` = 4.3s at 36 lessons. Fix:
+- Reset stagger counter at each realm boundary
+- Cap: `delay: Math.min(index * 0.12, 0.6)`
+- Use `whileInView` for off-screen realms (Framer Motion)
+
+**Accessibility:**
+- Touch targets: minimum 44x44px (current 32x32 is too small)
+- Each state uses icon + color (not color alone): checkmark, fire/arrow, lock
+- Realm headers as `<h2>` landmarks for screen reader navigation
+- Connector lines: `aria-hidden="true"`
+- Respect `prefers-reduced-motion`
+
+**Fog-reveal pattern:** Future realms shown as silhouettes. Reduces overwhelm, creates anticipation.
+
+### Code Sandbox (Future)
+
+**Recommendation: Sandpack + CodeMirror readonly-ranges**
+
+| Tool | Role | Bundle | License |
+|------|------|--------|---------|
+| `@codesandbox/sandpack-react` | Editor + execution + preview | ~200KB gzip | Apache-2.0 |
+| `codemirror-readonly-ranges` | Fill-in-the-blank locked regions | Included in Sandpack (CM6) | MIT |
+
+**Architecture:**
+- Realm 2 (JS fundamentals): `Sandpack(template="vanilla")` + `SandpackConsole` — write JS, see `console.log` output
+- Realm 3 (frontend): `Sandpack(template="static")` + `SandpackPreview` — write HTML/CSS/JS, see live preview
+- Fill-in-the-blank: CodeMirror `readonly-ranges` extension within Sandpack editor
+
+**Skip:** Monaco (5MB, overkill for kids), Pyodide (Python, wrong language), Judge0 (server dependency), WebContainers (commercial license, browser compat issues)
+
+**Implementation:** Create `components/CodePlayground.tsx` wrapper that selects Sandpack template by lesson type. Add when starting Realm 3 content.
+
+---
+
+## Content Authoring Pattern
+
+Each lesson file follows this exact structure (from `docs/solutions/feature-patterns/adding-lessons-and-step-types.md`):
+
+```
+content/lessons/{NN}-{slug}.ts
+```
+
+4 sections per lesson:
+1. **slides** — 4-6 frames with ASCII art, animations from `slide-variants.ts`
+2. **reading** — markdown with tables, code blocks, cheat sheets
+3. **interactive** — 2-4 steps using step types (sequence, fill-blank, type-command, multiple-choice, drag-drop)
+4. **quiz** — 5 questions, passingScore: 60, 0-indexed correctAnswer
+
+**FillBlank validation gotcha:** Template `___` count must match `blanks.length`, every `blank.id` must have a key in `solution`.
+
+**Boss convention:** `damagePerCorrect = maxHp / 5` (5 correct answers = kill), `playerMaxHp = 3`.
+
+---
+
+## References
+
+- Original curriculum map: `.claude/plans/synthetic-hatching-frog.md`
+- Lesson authoring patterns: `docs/solutions/feature-patterns/adding-lessons-and-step-types.md`
+- Infinite re-render fix: `docs/solutions/runtime-errors/server-action-starttransition-infinite-rerender.md`
+- Type system: `lib/types.ts`
+- Existing lessons: `content/lessons/01-07`
+- Boss sprites: `components/bosses/`
+- Issue #27: 30+ lessons request

--- a/docs/plans/2026-04-06-001-feat-xp-bonuses-interaction-logging-plan.md
+++ b/docs/plans/2026-04-06-001-feat-xp-bonuses-interaction-logging-plan.md
@@ -1,0 +1,385 @@
+---
+title: "feat: First-attempt bonus, interaction logging, comeback bonus"
+type: feat
+status: completed
+date: 2026-04-06
+---
+
+# feat: First-attempt bonus, interaction logging, comeback bonus
+
+## Overview
+
+Add three XP/engagement features: (1) 1.5x XP for first-attempt lesson completion, (2) granular interaction event logging for future secret badges, (3) tiered XP comeback bonus for returning after 3+ days away. This is Batch 2 of the progression system work (issue #36).
+
+## Problem Frame
+
+Kids need incentives beyond streak pressure. First-attempt bonus rewards focus. Comeback bonus prevents guilt when parents control screen time. Interaction logging is a data-first investment — we can't retroactively detect secret badge conditions ("Heroic Win", "Curious Mind") without capturing the raw events now.
+
+## Requirements Trace
+
+- R1. First completion of a lesson awards 1.5x base XP; "FIRST TRY!" callout on unlock screen
+- R2. `attempts` column in `lesson_progress` is incremented on each completion
+- R3. New `interaction_events` table captures: wrong answers (which question, what picked), boss HP at each answer, time per section, time per question, lesson revisits, section replays
+- R4. Interaction logging is async/non-blocking — never slows the lesson experience
+- R5. Comeback bonus tiers: 3d = 1.25x, 7d = 1.5x, 14d+ = 2x base XP on first lesson completion after absence
+- R6. "Welcome Back!" banner on dashboard when returning after 3+ days
+- R7. Interaction data is not parent-visible yet — pure data collection
+
+## Scope Boundaries
+
+- Secret badges are NOT built — only the data foundation
+- No parent dashboard changes (R7)
+- No changes to existing streak logic — comeback bonus is additive, not a replacement
+- No client-side analytics/telemetry library — just server action writes
+- Bonus XP stacking: first-attempt and comeback bonuses are independent. Each is a separate `xp_transactions` entry with its own reason, so they stack additively against the base XP
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/progress.ts:175-252` — `completeLesson()` orchestrates upsert → award_xp → updateStreak → unlockNext → badges
+- `lib/progress.ts:254-281` — `updateStreak()` reads `last_session_date`, updates to today
+- `lib/types.ts:183-191` — `LessonProgress` type (already has `attempts: number`)
+- `lib/types.ts:222-227` — `LessonCompletionResult` return type
+- `components/UnlockScreen.tsx` — staged animation cards (XP, Level, Streak, Score Tier, Badges)
+- `app/page.tsx:132-157` — `UnlockBanner` component pattern for dashboard conditional banners
+- `app/lesson/[slug]/page.tsx:137-160` — `handleQuizComplete` calls `completeLesson()` via `startTransition`
+- `app/actions/progress.ts` — thin server action wrappers over `lib/progress.ts`
+- `supabase/migrations/004_fixes.sql` — `award_xp` function with idempotency via partial unique indexes
+- `supabase/migrations/001_init.sql:34-47` — `lesson_progress` schema (`attempts INT DEFAULT 0` — never incremented)
+
+### Institutional Learnings
+
+- **Non-fatal side-effects** (`docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md`): All bonus XP and event logging must be wrapped in individual try/catch blocks. Never add to `Promise.all` with critical writes. The `user_badges` table absence crash is the cautionary tale.
+- **startTransition + Server Actions** (`docs/solutions/runtime-errors/server-action-starttransition-infinite-rerender.md`): Never use `startTransition` with Server Actions inside `useEffect`. The lesson player already follows the safe pattern — don't regress. New event logging calls must use plain async with `cancelled` flag.
+- **Singleton mutation** (`docs/solutions/runtime-errors/default-object-singleton-mutation.md`): If defining default bonus config objects at module scope, use factory functions (already established by `makeEmptyProfile()`).
+
+## Key Technical Decisions
+
+- **Separate XP transactions for bonuses**: Use distinct `reason` values (`"first_attempt_bonus"`, `"comeback_bonus"`) rather than inflating the base `"lesson_complete"` amount. This preserves base XP idempotency, makes bonuses independently trackable, and simplifies future analytics. Each bonus is idempotent via the existing partial unique indexes.
+- **Pre-read pattern for bonus detection**: Read current `lesson_progress.attempts` and `character_stats.last_session_date` at the top of `completeLesson()` before any writes. These two reads can be parallelized. This avoids race conditions with `updateStreak()` which updates `last_session_date` to today.
+- **Comeback bonus is per-absence, not per-session**: Only the first lesson completed after 3+ days away gets the comeback bonus. This happens naturally because `updateStreak()` sets `last_session_date = today` during the same `completeLesson()` call — subsequent completions see 0 days away.
+- **Interaction events as fire-and-forget server actions**: Client calls server action, doesn't await for UI flow. Server wraps insert in try/catch. No client-side batching in v1 — keep it simple with per-event writes.
+- **Generic event table with JSONB metadata**: Single `interaction_events` table with `event_type` enum + `metadata JSONB` rather than separate tables per event type. Flexible for future secret badge queries.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should bonuses stack?** Yes — they're independent multipliers recorded as separate transactions. A 100 XP lesson with both first-attempt and 7-day comeback: 100 (base) + 50 (first attempt) + 50 (comeback) = 200 XP total.
+- **When does "first attempt" count?** At completion time. If `lesson_progress.attempts === 0` before incrementing, it's the first attempt. Replaying a completed lesson doesn't get the bonus (attempts > 0).
+- **Comeback bonus scope?** First lesson completion after absence only (not all lessons in a session).
+
+### Deferred to Implementation
+
+- **Client-side event batching**: May be needed later if per-event writes cause performance issues. Start with simple per-event calls and measure.
+- **Exact metadata shape per event type**: The TypeScript type will define the union, but exact field names will be finalized during implementation based on what's easily accessible in each component.
+- **Score overwrite on replay**: The existing `completeLesson()` upsert overwrites `score` and `completed_at` on replay. A kid who replays and scores lower loses their high score. Now that `attempts` makes replays a tracked concept, a `GREATEST(OLD.score, NEW.score)` trigger may be warranted — but that's a separate concern from this batch.
+- **Comeback: `last_session_date` vs `last_active_at`**: A kid who visits daily but doesn't complete a lesson for a week would get a comeback bonus. This is intentional — the comeback rewards returning to *completion*, not just visiting. `last_session_date` is the correct signal.
+
+## Implementation Units
+
+- [ ] **Unit 1: Migration 006 — interaction_events table**
+
+**Goal:** Create the `interaction_events` table for granular kid interaction logging.
+
+**Requirements:** R3, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `supabase/migrations/006_interaction_events.sql`
+
+**Approach:**
+- Table: `interaction_events` with columns: `id UUID PK`, `user_id UUID FK`, `lesson_slug TEXT`, `event_type TEXT CHECK(event_type IN ('wrong_answer', 'boss_hp_snapshot', 'section_time', 'question_time', 'lesson_revisit', 'section_replay'))`, `metadata JSONB`, `created_at TIMESTAMPTZ`
+- Index on `(user_id, event_type)` for future badge queries
+- Index on `(user_id, lesson_slug)` for per-lesson event lookup
+- No RLS — same pattern as all other tables
+- Apply via: `psql postgresql://postgres:postgres@localhost:55122/postgres -f supabase/migrations/006_interaction_events.sql`
+
+**Patterns to follow:**
+- `supabase/migrations/005_badges.sql` — same header comment style, naming convention
+- `supabase/migrations/001_init.sql` — index and FK patterns
+
+**Test expectation:** none — pure DDL, verified by successful migration application
+
+**Verification:**
+- Table exists and accepts inserts
+- Indexes exist on `(user_id, event_type)` and `(user_id, lesson_slug)`
+
+---
+
+- [ ] **Unit 2: First-attempt bonus server logic**
+
+**Goal:** Award 1.5x XP on first lesson completion. Increment `attempts` on every completion.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None (uses existing schema — `attempts` column already exists)
+
+**Files:**
+- Modify: `lib/progress.ts`
+- Modify: `lib/types.ts`
+- Modify: `app/actions/progress.ts`
+- Test: `tests/progress.test.ts` (or inline verification)
+
+**Approach:**
+- At top of `completeLesson()`, read current `lesson_progress` row for `(userId, slug)` to get current `attempts` value
+- Determine `isFirstAttempt = !currentRow || currentRow.attempts === 0`
+- Include `attempts: (currentRow?.attempts ?? 0) + 1` in the lesson_progress upsert
+- After the existing `award_xp` call (not in the same `Promise.all`), if `isFirstAttempt`:
+  - Calculate `bonusXp = Math.floor(xp * 0.5)` (the extra 50% — base is already awarded)
+  - Call `award_xp(userId, bonusXp, "first_attempt_bonus", slug)` — idempotent via existing indexes
+  - Wrap in try/catch (non-fatal side-effect pattern)
+- Extend `LessonCompletionResult` with `isFirstAttempt?: boolean` and `bonusXp?: number`
+- Update `completeLesson()` return to include these fields
+- Update server action wrapper signature in `app/actions/progress.ts` (return type already inferred)
+
+**Patterns to follow:**
+- Non-fatal side-effect isolation pattern (`docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md`)
+- Existing `checkAndAwardBadges` try/catch pattern in `completeLesson()`
+
+**Test scenarios:**
+- Happy path: complete a lesson for the first time (attempts=0) → `isFirstAttempt=true`, bonus XP awarded, attempts becomes 1
+- Happy path: verify bonus amount is `Math.floor(baseXp * 0.5)` for various base XP values (50→25, 100→50, 75→37)
+- Edge case: replay a completed lesson (attempts>0) → `isFirstAttempt=false`, no bonus XP, attempts incremented
+- Edge case: bonus XP transaction is idempotent — calling completeLesson twice for same slug doesn't double-award
+- Error path: bonus XP award fails (e.g., DB error) → lesson still completes successfully, `isFirstAttempt` still true in result but `bonusXp` may be 0
+
+**Verification:**
+- `xp_transactions` has a row with reason `"first_attempt_bonus"` after first completion
+- `lesson_progress.attempts` is 1 after first completion, 2 after second
+- `LessonCompletionResult` includes `isFirstAttempt` and `bonusXp` fields
+
+---
+
+- [ ] **Unit 3: Comeback bonus server logic**
+
+**Goal:** Detect days since last session and award tiered XP bonus on first lesson completion after 3+ day absence.
+
+**Requirements:** R5
+
+**Dependencies:** None (uses existing `character_stats.last_session_date` column)
+
+**Files:**
+- Modify: `lib/progress.ts`
+- Modify: `lib/types.ts`
+
+**Approach:**
+- At top of `completeLesson()`, read `character_stats.last_session_date` for the user (can be parallelized with the Unit 2 lesson_progress read)
+- Calculate `daysAway` from `last_session_date` to today
+- Determine comeback tier: `daysAway >= 14 → 2.0`, `>= 7 → 1.5`, `>= 3 → 1.25`, else `null`
+- If comeback tier exists, after the bonus XP award (Unit 2):
+  - Calculate `comebackBonusXp = Math.floor(xp * (multiplier - 1))` (just the extra portion)
+  - Call `award_xp(userId, comebackBonusXp, "comeback_bonus", slug)` — idempotent per lesson
+  - Wrap in try/catch (non-fatal)
+- Extend `LessonCompletionResult` with `comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number }`
+- Natural one-time behavior: `updateStreak()` sets `last_session_date = today`, so the next `completeLesson()` in the same session sees 0 days away
+- Extend `PlayerProfile` with `daysAway?: number` for dashboard use (set in `loadDashboard`). If `last_session_date` is null (new user, no prior session), set `daysAway` to 0 — no comeback bonus for first-ever session
+
+**Patterns to follow:**
+- Same non-fatal try/catch pattern as Unit 2
+- `updateStreak()` date comparison pattern for days-away calculation
+
+**Test scenarios:**
+- Happy path: 3 days away → multiplier 1.25x, base 100 XP → 25 bonus XP (reason: comeback_bonus)
+- Happy path: 7 days away → multiplier 1.5x, base 100 XP → 50 bonus XP
+- Happy path: 14+ days away → multiplier 2.0x, base 100 XP → 100 bonus XP
+- Happy path: first-attempt + comeback stack → base 100 + 50 (first attempt) + 50 (comeback 7d) = 200 XP total
+- Edge case: 2 days away → no comeback bonus
+- Edge case: `last_session_date` is null (brand new user, first ever lesson) → no comeback bonus (no prior session to return from)
+- Edge case: second lesson in same session → `last_session_date` already updated to today → no duplicate comeback bonus
+- Error path: comeback bonus XP award fails → lesson still completes, comeback info still in result
+
+**Verification:**
+- `xp_transactions` has row with reason `"comeback_bonus"` when comeback triggers
+- Comeback bonus fires only once per absence (second lesson same session gets no bonus)
+- `LessonCompletionResult.comebackBonus` populated with correct tier info
+
+---
+
+- [ ] **Unit 4: Interaction event logging infrastructure**
+
+**Goal:** Create server-side event logging module and server actions for fire-and-forget interaction capture.
+
+**Requirements:** R3, R4, R7
+
+**Dependencies:** Unit 1 (interaction_events table must exist)
+
+**Files:**
+- Create: `lib/events.ts`
+- Create: `app/actions/events.ts`
+
+**Approach:**
+- `lib/events.ts`:
+  - Define `InteractionEventType` union type matching the CHECK constraint event types
+  - Define metadata type per event (discriminated union or loose JSONB — start loose)
+  - `logInteractionEvent(userId, lessonSlug, eventType, metadata)` function: single insert, wrapped in try/catch, returns void (never throws)
+  - `logInteractionEvents(events[])` bulk variant: single multi-row insert for efficiency when flushing multiple events at section end
+- `app/actions/events.ts`:
+  - `"use server"` wrapper for `logInteractionEvent` and `logInteractionEvents`
+  - Same thin delegation pattern as `app/actions/progress.ts`
+- All writes are non-fatal — the function catches errors internally and logs to console.error
+
+**Patterns to follow:**
+- `app/actions/progress.ts` — thin server action wrapper pattern
+- `lib/badges.ts` — module structure with exported functions
+- Non-fatal side-effect pattern from docs/solutions
+
+**Test scenarios:**
+- Happy path: log a `wrong_answer` event with metadata `{ questionIndex: 2, selectedOption: "B", correctOption: "C" }` → row inserted in `interaction_events`
+- Happy path: log a `boss_hp_snapshot` event with metadata `{ bossHp: 3, playerHp: 1, questionIndex: 4 }` → row inserted
+- Happy path: bulk insert 5 events via `logInteractionEvents` → all 5 rows created
+- Error path: table doesn't exist (migration not applied) → function returns without throwing, console.error logged
+- Error path: malformed metadata → insert fails gracefully, no crash propagation
+
+**Verification:**
+- Events appear in `interaction_events` table after server action calls
+- Lesson completion flow is unaffected when event logging is called alongside it
+
+---
+
+- [ ] **Unit 5: Client-side interaction logging calls**
+
+**Goal:** Wire up interaction event capture in quiz, boss battle, and interactive exercise components.
+
+**Requirements:** R3, R4
+
+**Dependencies:** Unit 4 (server actions must exist)
+
+**Files:**
+- Modify: `components/QuizSection.tsx`
+- Modify: `components/BossBattleSection.tsx`
+- Modify: `components/InteractiveExercise.tsx`
+- Modify: `app/lesson/[slug]/page.tsx`
+
+**Approach:**
+- **userId threading**: QuizSection, BossBattleSection, and InteractiveExercise currently don't receive `userId` as a prop. Add `userId: string` and `lessonSlug: string` props to each component (threaded from lesson player page which already has both). Alternatively, centralize logging in the lesson player by passing event callbacks down instead of having components call server actions directly.
+- **Wrong answers**: In QuizSection and BossBattleSection, when a wrong answer is selected, fire `logInteractionEvent(userId, slug, "wrong_answer", { questionIndex, selectedOption, correctOption })`
+- **Boss HP snapshots**: In BossBattleSection, after each answer (right or wrong), fire `logInteractionEvent(userId, slug, "boss_hp_snapshot", { bossHp, playerHp, questionIndex, wasCorrect })`
+- **Section time**: Track `Date.now()` at section start in the lesson player. On section complete, fire `logInteractionEvent(userId, slug, "section_time", { sectionIndex, sectionType, durationMs })`
+- **Question time**: Track per-question start time in quiz/boss components. On answer, include `durationMs` in the event metadata
+- **Lesson revisits**: In lesson player, if loading a lesson that's already `completed`, fire `logInteractionEvent(userId, slug, "lesson_revisit", {})`
+- **Section replays**: If navigating to a section with index < current progress, fire `logInteractionEvent(userId, slug, "section_replay", { sectionIndex })`
+- All calls are fire-and-forget: call the server action but don't await it in the UI flow. Use plain async IIFE pattern (NOT startTransition).
+- userId comes from `useActiveUser()` hook, already available in all these components
+
+**Patterns to follow:**
+- Plain async call pattern (not startTransition) per the infinite re-render solution doc
+- Fire-and-forget pattern from existing `updateLessonProgress` debounced calls
+
+**Test scenarios:**
+- Happy path: answer a quiz question wrong → `wrong_answer` event logged with correct metadata
+- Happy path: complete a boss battle → multiple `boss_hp_snapshot` events logged throughout the fight
+- Happy path: complete a section → `section_time` event logged with duration
+- Edge case: very fast section completion (< 1 second) → event still logged with small duration
+- Edge case: lesson revisit detection only fires for `completed` lessons, not `in_progress`
+- Integration: complete a full lesson → multiple interaction events created without slowing the completion flow
+
+**Verification:**
+- Playing through a lesson creates interaction_events rows for each supported event type
+- Lesson UX timing is unaffected (events are fire-and-forget)
+- No console errors from event logging during normal gameplay
+
+---
+
+- [ ] **Unit 6: UnlockScreen bonus callouts**
+
+**Goal:** Show "FIRST TRY!" and comeback bonus cards on the unlock screen when earned.
+
+**Requirements:** R1 (callout), R5 (visual)
+
+**Dependencies:** Units 2, 3 (server returns bonus data)
+
+**Files:**
+- Modify: `components/UnlockScreen.tsx`
+- Modify: `app/lesson/[slug]/page.tsx`
+
+**Approach:**
+- Extend `UnlockScreenProps` with `isFirstAttempt?: boolean`, `bonusXp?: number`, `comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number }`
+- In lesson page `handleQuizComplete`, pass new fields from `LessonCompletionResult` to `unlockData`
+- Update `xpEarned` in `unlockData` to total XP (base + all bonuses). The XP counter animates to the grand total for maximum "wow" factor. Bonus cards show the breakdown of what contributed (e.g., "+50 FIRST TRY!", "+50 COMEBACK!") so the kid understands where the extra came from
+- **"FIRST TRY!" card**: New stat card after Score Tier, before Badges. Gold accent, spring animation with next sequential delay. Shows "FIRST TRY!" label + "+{bonusXp} XP" value. Play `sfx("level-up")` or similar celebratory sound.
+- **Comeback bonus card**: If comeback bonus exists, show "WELCOME BACK!" card with tier info and bonus XP. Fire/warm accent color. Include days-away context ("7 days → 1.5x").
+- Both cards use the same `rpg-card` + spring animation pattern as existing stat cards
+
+**Patterns to follow:**
+- Existing stat card pattern in UnlockScreen (lines 148-235): `motion.div` with `initial/animate`, sequential delay, `rpg-card` class
+- Responsive: `px-6 py-4`, `text-sm` labels
+
+**Test scenarios:**
+- Happy path: first-attempt completion → "FIRST TRY!" card visible with bonus XP amount, celebratory SFX
+- Happy path: comeback completion (7 days away) → "WELCOME BACK!" card with "1.5x" indicator and bonus XP
+- Happy path: both bonuses earned → both cards appear in sequence
+- Edge case: neither bonus → no extra cards, existing layout unchanged
+- Edge case: comeback bonus earned but not first attempt → only comeback card shows
+
+**Verification:**
+- Visual: unlock screen shows bonus cards with correct amounts when earned
+- Audio: celebratory SFX plays for bonus cards
+- Layout: cards fit cleanly between Score Tier and Badges sections
+
+---
+
+- [ ] **Unit 7: Dashboard "Welcome Back!" banner**
+
+**Goal:** Show a "Welcome Back!" banner on the dashboard when the kid returns after 3+ days.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 3 (`PlayerProfile.daysAway` field)
+
+**Files:**
+- Modify: `app/page.tsx`
+- Modify: `lib/progress.ts` (loadDashboard to populate daysAway)
+
+**Approach:**
+- In `loadDashboard()`, after `getProfile()`, compute `daysAway` from `profile.lastSessionDate` vs today. Attach to profile as `daysAway`.
+- In dashboard page, render a `ComebackBanner` component above the lesson list when `profile.daysAway >= 3`
+- Banner style: warm gradient (fire-orange/gold), similar structure to `UnlockBanner` but distinct
+- Gate on `profile.role === "child"` — parents don't play lessons, showing them "earn 2x XP!" is misleading
+- Show tier info: "Welcome back! You've been away {N} days — earn {multiplier}x XP on your next lesson!"
+- Banner disappears on the next dashboard load after lesson completion (since `completeLesson()` calls `updateStreak()` which sets `last_session_date` to today, `daysAway` will recompute to 0)
+- No server action call from the banner — it's purely presentational based on profile data
+
+**Patterns to follow:**
+- `UnlockBanner` component pattern at `app/page.tsx:132-157`
+- Framer motion `initial/animate` transitions
+- Responsive text: `text-sm sm:text-base`
+
+**Test scenarios:**
+- Happy path: return after 7 days → banner shows with "1.5x" multiplier info
+- Happy path: return after 14+ days → banner shows with "2x" multiplier info
+- Edge case: return after 2 days → no banner
+- Edge case: complete a lesson, return to dashboard → banner gone (last_session_date is now today)
+- Edge case: brand new user (no last_session_date) → no banner
+- Edge case: parent account returning after 7 days → no banner (role guard)
+
+**Verification:**
+- Visual: banner renders above lesson list with correct tier info
+- Banner is gone after completing a lesson and returning to dashboard
+
+## System-Wide Impact
+
+- **Interaction graph:** `completeLesson()` gains two new `award_xp` calls (first-attempt, comeback) — both are independently idempotent and non-fatal. `handleQuizComplete` passes new data through to `UnlockScreen`. Dashboard reads `daysAway` from profile.
+- **Error propagation:** All new XP awards and event logging are wrapped in try/catch. A failure in any bonus or logging path must never crash lesson completion. This matches the established pattern from the badge crash incident.
+- **State lifecycle risks:** The `attempts` increment and bonus XP award could theoretically race if `completeLesson()` is called twice rapidly for the same lesson — but `award_xp` idempotency prevents double-awarding, and the `attempts` value may be off by one in the race case (acceptable).
+- **API surface parity:** `LessonCompletionResult` gains optional fields (`isFirstAttempt`, `bonusXp`, `comebackBonus`). Backward-compatible — existing consumers see `undefined` for new fields.
+- **Unchanged invariants:** Existing XP award (`lesson_complete` reason), streak logic, badge checks, unlock flow — all unchanged. The new code adds parallel side-effect paths, not modifications to the critical path.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Event logging inserts slow down lesson experience | Fire-and-forget pattern — client doesn't await. Server wraps in try/catch. No impact on critical path. |
+| Migration 006 not applied in an environment | Event logging function degrades silently (try/catch). Bonus XP uses existing tables — no migration dependency. |
+| `attempts` column race on rapid re-completion | `award_xp` idempotency prevents double bonus. Worst case: attempts count is slightly off, which has no user-facing consequence. |
+| Comeback bonus race: two concurrent completions both see stale `last_session_date` | Each awards a different lesson's comeback bonus — `award_xp` dedupes on `(user_id, lesson_slug, "comeback_bonus")`. Two different lessons getting comeback bonus in the same return is acceptable and unlikely (sequential lesson flow). |
+| Comeback bonus calculated wrong due to timezone | Use ISO date string comparison (same pattern as `updateStreak()`). Both use `new Date().toISOString().split("T")[0]` — consistent. |
+
+## Sources & References
+
+- Related issue: #36
+- Key files: `lib/progress.ts`, `lib/types.ts`, `components/UnlockScreen.tsx`, `app/page.tsx`
+- Learnings: `docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md`
+- Learnings: `docs/solutions/runtime-errors/server-action-starttransition-infinite-rerender.md`

--- a/docs/solutions/best-practices/pre-read-pattern-before-transactional-writes-2026-04-07.md
+++ b/docs/solutions/best-practices/pre-read-pattern-before-transactional-writes-2026-04-07.md
@@ -1,0 +1,137 @@
+---
+title: "Pre-read baseline values before transactional writes that overwrite them"
+date: 2026-04-07
+category: docs/solutions/best-practices
+module: lesson completion / XP bonuses / streak tracking
+problem_type: best_practice
+component: service_object
+severity: high
+applies_when:
+  - A function needs a "before" value to compute a bonus or delta, but that value is overwritten by a write later in the same function
+  - Computing whether something is a "first attempt" when the attempt count is incremented by the same operation
+  - Computing time-since-last-visit when the last-visit timestamp is updated by the same operation
+  - Any conditional logic that must branch on a pre-write state
+tags:
+  - pre-read
+  - transactional
+  - promise-all
+  - xp-bonus
+  - first-attempt
+  - comeback-bonus
+  - safe-direction
+  - baseline
+related_components:
+  - database
+---
+
+# Pre-read baseline values before transactional writes that overwrite them
+
+## Context
+
+`completeLesson()` in `lib/progress.ts` was extended (PR #44) to award two new XP bonuses:
+
+1. **First-attempt bonus** (1.5x) — awarded when the player completes a lesson without any prior failed attempts.
+2. **Comeback bonus** (tiered: 1.25x at 3d, 1.5x at 7d, 2x at 14d+) — awarded when the player returns after an absence.
+
+Both computations require knowing a value *before* the function's own writes:
+
+- First-attempt requires the current `attempts` count. The upsert later in the same function increments it.
+- Comeback requires `last_session_date`. `updateStreak()` later in the same function overwrites it to today.
+
+Reading those values *after* the writes always returns the post-write state, making first-attempt detection impossible (attempts is already 1) and comeback detection impossible (last session is already today).
+
+## Guidance
+
+**Parallelize all required pre-reads at the top of the function, before any writes.** Use `Promise.all` so both reads are concurrent. Apply safe-direction defaults on failure — default toward *not* awarding a bonus, not toward awarding one.
+
+```typescript
+// Pre-read before writes — both reads parallelized
+const [existingProgressResult, statsPreResult] = await Promise.all([
+  supabase
+    .from("lesson_progress")
+    .select("attempts")
+    .eq("user_id", userId)
+    .eq("lesson_slug", slug)
+    .maybeSingle(),
+  supabase
+    .from("character_stats")
+    .select("last_session_date")
+    .eq("user_id", userId)
+    .maybeSingle(),
+]);
+
+// Safe-direction defaults: on DB error, assume non-first-attempt and no comeback
+const currentAttempts = existingProgressResult.error
+  ? 1
+  : (existingProgressResult.data?.attempts ?? 0);
+const lastSessionDate = statsPreResult.error
+  ? null
+  : (statsPreResult.data?.last_session_date ?? null);
+
+// ... all writes follow here (upsert, updateStreak, award XP, etc.) ...
+```
+
+Then derive the bonuses from the pre-read values, not from values fetched later:
+
+```typescript
+const isFirstAttempt = currentAttempts === 0;
+const xpMultiplier = computeXpMultiplier(isFirstAttempt, lastSessionDate);
+```
+
+## Why This Matters
+
+A function that reads, then writes, then needs the pre-write value is a classic temporal ordering bug. The database always reflects the most recent state — there is no built-in "before image" unless you read it explicitly before writing.
+
+The safe-direction default principle is equally important. If the pre-read fails (transient network error, cold connection, etc.), the system must not award bonuses it cannot verify. Defaulting `currentAttempts = 1` (non-first-attempt) and `lastSessionDate = null` (no comeback) means a rare DB hiccup causes a missed bonus for one player once — not a systematic over-award across many sessions.
+
+Awarding a bonus that wasn't earned is worse than missing one: it is irreversible, degrades the economy, and undermines player trust in the fairness of the system.
+
+## When to Apply
+
+- Any function that needs a "before" snapshot of a value it will later overwrite.
+- Any bonus, delta, or conditional that must branch on pre-write state.
+- Streak calculations, attempt counts, session timestamps — all are overwritten by the function that also needs them.
+- Wherever the pre-reads are independent, use `Promise.all` to avoid serializing them unnecessarily.
+
+## Examples
+
+**Anti-pattern — reading after the write loses the baseline:**
+
+```typescript
+// WRONG: attempts is read after the upsert that increments it
+await supabase.from("lesson_progress").upsert({ attempts: existingAttempts + 1 });
+const { data } = await supabase.from("lesson_progress").select("attempts").maybeSingle();
+const isFirstAttempt = data?.attempts === 1; // always false — it's already 1 after upsert
+```
+
+**Correct pattern — pre-read, then write:**
+
+```typescript
+// RIGHT: read attempts before the upsert
+const { data: existing } = await supabase
+  .from("lesson_progress")
+  .select("attempts")
+  .eq("user_id", userId)
+  .eq("lesson_slug", slug)
+  .maybeSingle();
+const currentAttempts = existing?.attempts ?? 0;
+const isFirstAttempt = currentAttempts === 0;
+
+// NOW do the write
+await supabase.from("lesson_progress").upsert({ attempts: currentAttempts + 1 });
+```
+
+**Safe-direction default on failure:**
+
+```typescript
+// If the pre-read errors, default toward NOT awarding the bonus
+const currentAttempts = existingProgressResult.error
+  ? 1   // treat as "already attempted" — safe direction
+  : (existingProgressResult.data?.attempts ?? 0);
+```
+
+## Related
+
+- `lib/progress.ts` — `completeLesson()` implements this pattern for both pre-reads
+- `docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md` — companion pattern: isolating non-critical side-effects from the same critical path
+- PR #44 (`feat/xp-bonuses-interaction-logging`) — where this pattern was introduced

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -5,6 +5,10 @@
 
 import { supabase } from "@/lib/supabase";
 
+/**
+ * Must match the CHECK constraint in supabase/migrations/006_interaction_events.sql.
+ * Adding a new value requires both a DB migration and an update here.
+ */
 export type InteractionEventType =
   | "wrong_answer"
   | "boss_hp_snapshot"

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,69 @@
+// Interaction event logging — server-only.
+// All functions are non-fatal: they catch and log errors internally,
+// never throwing to the caller. Lesson completion must never be blocked
+// by a logging failure.
+
+import { supabase } from "@/lib/supabase";
+
+export type InteractionEventType =
+  | "wrong_answer"
+  | "boss_hp_snapshot"
+  | "section_time"
+  | "question_time"
+  | "lesson_revisit"
+  | "section_replay";
+
+export interface InteractionEvent {
+  userId: string;
+  lessonSlug: string;
+  eventType: InteractionEventType;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Log a single interaction event. Fire-and-forget — never throws.
+ */
+export async function logInteractionEvent(
+  userId: string,
+  lessonSlug: string,
+  eventType: InteractionEventType,
+  metadata: Record<string, unknown> = {}
+): Promise<void> {
+  try {
+    const { error } = await supabase.from("interaction_events").insert({
+      user_id: userId,
+      lesson_slug: lessonSlug,
+      event_type: eventType,
+      metadata,
+    });
+    if (error) {
+      console.error("[logInteractionEvent] insert failed:", error.message);
+    }
+  } catch (err) {
+    console.error("[logInteractionEvent] unexpected error:", err);
+  }
+}
+
+/**
+ * Bulk insert multiple interaction events. More efficient than per-event
+ * calls when flushing a batch at section end. Never throws.
+ */
+export async function logInteractionEvents(
+  events: InteractionEvent[]
+): Promise<void> {
+  if (events.length === 0) return;
+  try {
+    const rows = events.map((e) => ({
+      user_id: e.userId,
+      lesson_slug: e.lessonSlug,
+      event_type: e.eventType,
+      metadata: e.metadata,
+    }));
+    const { error } = await supabase.from("interaction_events").insert(rows);
+    if (error) {
+      console.error("[logInteractionEvents] bulk insert failed:", error.message);
+    }
+  } catch (err) {
+    console.error("[logInteractionEvents] unexpected error:", err);
+  }
+}

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -3,7 +3,7 @@
 // localStorage reads live in lib/progress-client.ts.
 
 import { supabase } from "@/lib/supabase";
-import { calculateLevel, XP_PER_LEVEL } from "@/lib/types";
+import { calculateLevel, XP_PER_LEVEL, getComebackMultiplier } from "@/lib/types";
 import type {
   PlayerProfile,
   LessonProgress,
@@ -179,7 +179,9 @@ export async function completeLesson(
   xp: number
 ): Promise<LessonCompletionResult> {
   // Pre-read attempts and last_session_date in parallel before any writes.
-  // Must happen before updateStreak() which sets last_session_date = today.
+  // Both reads must precede writes:
+  //   (1) attempts is used to compute currentAttempts+1 and isFirstAttempt before the upsert overwrites it
+  //   (2) last_session_date must be read before updateStreak() overwrites it with today
   const today = new Date().toISOString().split("T")[0];
   const [existingProgressResult, statsPreResult] = await Promise.all([
     supabase
@@ -195,18 +197,30 @@ export async function completeLesson(
       .maybeSingle(),
   ]);
 
-  const currentAttempts = existingProgressResult.data?.attempts ?? 0;
+  // On pre-read failure, default to safe direction: assume already attempted / no comeback.
+  // This prevents spurious bonus awards if the DB read fails transiently.
+  if (existingProgressResult.error) {
+    console.error("[completeLesson] attempts pre-read failed — assuming non-first attempt:", existingProgressResult.error.message);
+  }
+  if (statsPreResult.error) {
+    console.error("[completeLesson] stats pre-read failed — comeback bonus skipped:", statsPreResult.error.message);
+  }
+
+  const currentAttempts = existingProgressResult.error
+    ? 1  // safe fallback: treat as already attempted — never over-award first-attempt bonus
+    : (existingProgressResult.data?.attempts ?? 0);
   const isFirstAttempt = currentAttempts === 0;
 
-  const lastSessionDate = statsPreResult.data?.last_session_date ?? null;
+  const lastSessionDate = statsPreResult.error
+    ? null  // safe fallback: no comeback bonus on read failure
+    : (statsPreResult.data?.last_session_date ?? null);
   const daysAway = lastSessionDate
     ? Math.floor(
         (new Date(today).getTime() - new Date(lastSessionDate).getTime()) /
           (1000 * 60 * 60 * 24)
       )
     : 0;
-  const comebackMultiplier =
-    daysAway >= 14 ? 2.0 : daysAway >= 7 ? 1.5 : daysAway >= 3 ? 1.25 : null;
+  const comebackMultiplier = getComebackMultiplier(daysAway);
 
   const { error: progressError } = await supabase
     .from("lesson_progress")
@@ -225,8 +239,8 @@ export async function completeLesson(
     );
   if (progressError) throw new Error(progressError.message);
 
-  // award_xp is idempotent via partial unique indexes (migration 004).
-  // No existence pre-check needed — DB rejects duplicates atomically.
+  // award_xp is idempotent via partial unique indexes defined in migration 001.
+  // No existence pre-check needed — DB rejects duplicates via ON CONFLICT DO NOTHING atomically.
   const [xpResult] = await Promise.all([
     supabase.rpc("award_xp", {
       p_user_id: userId,
@@ -238,24 +252,28 @@ export async function completeLesson(
   ]);
   if (xpResult.error) throw new Error(xpResult.error.message);
 
-  // First-attempt bonus: +50% XP, non-fatal side-effect
-  // supabase.rpc() never throws — check .error explicitly
-  let bonusXp = 0;
+  // First-attempt bonus: +50% XP, non-fatal side-effect.
+  // supabase.rpc() resolves rather than throws — network errors are converted to { error }
+  // by the client. (Note: updateStreak() in the Promise.all above does throw on error.)
+  let firstAttemptBonusXp = 0;
   if (isFirstAttempt) {
-    bonusXp = Math.floor(xp * 0.5);
+    firstAttemptBonusXp = Math.floor(xp * 0.5);
     const firstAttemptResult = await supabase.rpc("award_xp", {
       p_user_id: userId,
-      p_amount: bonusXp,
+      p_amount: firstAttemptBonusXp,
       p_reason: "first_attempt_bonus",
       p_lesson: slug,
     });
     if (firstAttemptResult.error) {
       console.error("[completeLesson] first-attempt bonus failed — lesson completion still succeeds:", firstAttemptResult.error.message);
-      bonusXp = 0;
+      firstAttemptBonusXp = 0;
     }
   }
 
-  // Comeback bonus: tiered XP for returning after 3+ days, non-fatal side-effect
+  // Comeback bonus: tiered XP for returning after 3+ days, non-fatal side-effect.
+  // Note: idempotency key is (user_id, lesson_slug, "comeback_bonus") — a specific lesson
+  // can only earn this bonus once ever. In practice, kids progress forward and rarely replay
+  // the same lesson after multiple absences, so this is acceptable per the original design.
   let comebackBonusResult: LessonCompletionResult["comebackBonus"] | undefined;
   if (comebackMultiplier !== null) {
     const comebackBonusXp = Math.floor(xp * (comebackMultiplier - 1));
@@ -313,8 +331,9 @@ export async function completeLesson(
     level: statsResult.data?.current_level ?? 1,
     streak: statsResult.data?.streak_days ?? 0,
     newBadges: newBadges.length > 0 ? newBadges : undefined,
-    isFirstAttempt,
-    bonusXp: isFirstAttempt ? bonusXp : undefined,
+    firstAttemptBonus: isFirstAttempt && firstAttemptBonusXp > 0
+      ? { bonusXp: firstAttemptBonusXp }
+      : undefined,
     comebackBonus: comebackBonusResult,
   };
 }
@@ -418,6 +437,5 @@ export async function loadDashboard(
           (1000 * 60 * 60 * 24)
       )
     : 0;
-
   return { ...profile, daysAway };
 }

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -178,6 +178,36 @@ export async function completeLesson(
   score: number,
   xp: number
 ): Promise<LessonCompletionResult> {
+  // Pre-read attempts and last_session_date in parallel before any writes.
+  // Must happen before updateStreak() which sets last_session_date = today.
+  const today = new Date().toISOString().split("T")[0];
+  const [existingProgressResult, statsPreResult] = await Promise.all([
+    supabase
+      .from("lesson_progress")
+      .select("attempts")
+      .eq("user_id", userId)
+      .eq("lesson_slug", slug)
+      .maybeSingle(),
+    supabase
+      .from("character_stats")
+      .select("last_session_date")
+      .eq("user_id", userId)
+      .maybeSingle(),
+  ]);
+
+  const currentAttempts = existingProgressResult.data?.attempts ?? 0;
+  const isFirstAttempt = currentAttempts === 0;
+
+  const lastSessionDate = statsPreResult.data?.last_session_date ?? null;
+  const daysAway = lastSessionDate
+    ? Math.floor(
+        (new Date(today).getTime() - new Date(lastSessionDate).getTime()) /
+          (1000 * 60 * 60 * 24)
+      )
+    : 0;
+  const comebackMultiplier =
+    daysAway >= 14 ? 2.0 : daysAway >= 7 ? 1.5 : daysAway >= 3 ? 1.25 : null;
+
   const { error: progressError } = await supabase
     .from("lesson_progress")
     .upsert(
@@ -188,6 +218,7 @@ export async function completeLesson(
         score,
         xp_earned: xp,
         section_index: 0,
+        attempts: currentAttempts + 1,
         completed_at: new Date().toISOString(),
       },
       { onConflict: "user_id,lesson_slug" }
@@ -206,6 +237,40 @@ export async function completeLesson(
     updateStreak(userId),
   ]);
   if (xpResult.error) throw new Error(xpResult.error.message);
+
+  // First-attempt bonus: +50% XP, non-fatal side-effect
+  // supabase.rpc() never throws — check .error explicitly
+  let bonusXp = 0;
+  if (isFirstAttempt) {
+    bonusXp = Math.floor(xp * 0.5);
+    const firstAttemptResult = await supabase.rpc("award_xp", {
+      p_user_id: userId,
+      p_amount: bonusXp,
+      p_reason: "first_attempt_bonus",
+      p_lesson: slug,
+    });
+    if (firstAttemptResult.error) {
+      console.error("[completeLesson] first-attempt bonus failed — lesson completion still succeeds:", firstAttemptResult.error.message);
+      bonusXp = 0;
+    }
+  }
+
+  // Comeback bonus: tiered XP for returning after 3+ days, non-fatal side-effect
+  let comebackBonusResult: LessonCompletionResult["comebackBonus"] | undefined;
+  if (comebackMultiplier !== null) {
+    const comebackBonusXp = Math.floor(xp * (comebackMultiplier - 1));
+    const comebackResult = await supabase.rpc("award_xp", {
+      p_user_id: userId,
+      p_amount: comebackBonusXp,
+      p_reason: "comeback_bonus",
+      p_lesson: slug,
+    });
+    if (comebackResult.error) {
+      console.error("[completeLesson] comeback bonus failed — lesson completion still succeeds:", comebackResult.error.message);
+    } else {
+      comebackBonusResult = { daysAway, multiplier: comebackMultiplier, bonusXp: comebackBonusXp };
+    }
+  }
 
   await unlockNextLesson(userId, slug);
 
@@ -248,6 +313,9 @@ export async function completeLesson(
     level: statsResult.data?.current_level ?? 1,
     streak: statsResult.data?.streak_days ?? 0,
     newBadges: newBadges.length > 0 ? newBadges : undefined,
+    isFirstAttempt,
+    bonusXp: isFirstAttempt ? bonusXp : undefined,
+    comebackBonus: comebackBonusResult,
   };
 }
 
@@ -340,5 +408,16 @@ export async function loadDashboard(
   userId: string
 ): Promise<PlayerProfile | null> {
   await checkAndUnlockNextLesson(userId);
-  return getProfile(userId);
+  const profile = await getProfile(userId);
+  if (!profile) return null;
+
+  const today = new Date().toISOString().split("T")[0];
+  const daysAway = profile.lastSessionDate
+    ? Math.floor(
+        (new Date(today).getTime() - new Date(profile.lastSessionDate).getTime()) /
+          (1000 * 60 * 60 * 24)
+      )
+    : 0;
+
+  return { ...profile, daysAway };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -220,14 +220,25 @@ export type LookupResult =
   | { found: true; profile: PlayerProfile; session: UserSession }
   | { found: false };
 
+// Comeback multiplier tiers — 3d/7d/14d+ thresholds.
+// Must stay in sync with ComebackBanner display logic in app/page.tsx.
+export type ComebackMultiplier = 1.25 | 1.5 | 2.0;
+
+export function getComebackMultiplier(daysAway: number): ComebackMultiplier | null {
+  if (daysAway >= 14) return 2.0;
+  if (daysAway >= 7)  return 1.5;
+  if (daysAway >= 3)  return 1.25;
+  return null;
+}
+
 // Return type for completeLesson Server Action
 export interface LessonCompletionResult {
   level: number;
   streak: number;
   newBadges?: NewlyAwardedBadge[];
-  isFirstAttempt?: boolean;
-  bonusXp?: number;
-  comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number };
+  // Presence of the object is the flag — no separate isFirstAttempt boolean needed
+  firstAttemptBonus?: { bonusXp: number };
+  comebackBonus?: { daysAway: number; multiplier: ComebackMultiplier; bonusXp: number };
 }
 
 // Narrowed patch type for updateLessonProgress — only fields safe to update mid-session

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -201,6 +201,7 @@ export interface PlayerProfile {
   xpToNextLevel: number;
   streak: number;
   lastSessionDate?: string;
+  daysAway?: number;
   totalLessonsCompleted: number;
   unlockedToday: boolean;
   lessons: Record<string, LessonProgress>;
@@ -224,6 +225,9 @@ export interface LessonCompletionResult {
   level: number;
   streak: number;
   newBadges?: NewlyAwardedBadge[];
+  isFirstAttempt?: boolean;
+  bonusXp?: number;
+  comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number };
 }
 
 // Narrowed patch type for updateLessonProgress — only fields safe to update mid-session

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --webpack -p 3100",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "db": "psql postgresql://postgres:postgres@localhost:55122/postgres",
+    "db:migrate": "psql postgresql://postgres:postgres@localhost:55122/postgres -f"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.79.0",

--- a/supabase/migrations/006_interaction_events.sql
+++ b/supabase/migrations/006_interaction_events.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- KidKode — Migration 006: Interaction Events
+-- ============================================================
+-- Granular kid interaction logging for future secret badge queries.
+-- Data is captured async/non-blocking — never on the critical lesson path.
+-- Not parent-visible in v1 — pure data foundation.
+-- ============================================================
+
+CREATE TABLE public.interaction_events (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  lesson_slug TEXT        NOT NULL,
+  event_type  TEXT        NOT NULL CHECK (event_type IN (
+                            'wrong_answer',
+                            'boss_hp_snapshot',
+                            'section_time',
+                            'question_time',
+                            'lesson_revisit',
+                            'section_replay'
+                          )),
+  metadata    JSONB       NOT NULL DEFAULT '{}',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- For future badge queries: "how many wrong answers did this user get?"
+CREATE INDEX idx_interaction_events_user_type
+  ON public.interaction_events(user_id, event_type);
+
+-- For per-lesson event lookup: "all events for this user in this lesson"
+CREATE INDEX idx_interaction_events_user_lesson
+  ON public.interaction_events(user_id, lesson_slug);


### PR DESCRIPTION
Closes #36 (Batch 2).

## Summary

- **First-attempt bonus** — 1.5x XP (base + 50%) on first lesson completion; "FIRST TRY!" card on unlock screen
- **Comeback bonus** — tiered XP on return after 3+ days (1.25x/1.5x/2x); "WELCOME BACK!" card on unlock screen + dashboard banner  
- **Interaction event logging** — `interaction_events` table (migration 006) + fire-and-forget server actions capturing wrong answers, boss HP snapshots, section times, lesson revisits, section replays. Pure data foundation for future secret badges — not parent-visible.

## Technical notes

- Pre-reads `lesson_progress.attempts` and `character_stats.last_session_date` in parallel **before** any writes (before `updateStreak()` updates `last_session_date` to today)
- All bonus XP awards use distinct `reason` values — idempotent via existing partial unique indexes in `xp_transactions`
- Bonus/logging failures wrapped in error-checked non-fatal paths (matching the established pattern from the badge crash incident)
- Comeback bonus naturally fires only once per absence — `updateStreak()` sets `last_session_date = today` during the same call
- Event logging is fire-and-forget (`void` calls, no await in UI flow) — never blocks lesson experience
- No unit test runner in project (Playwright only) — TypeScript passes clean

## Post-Deploy Monitoring & Validation

**Log queries to run after first real completions:**
```sql
-- Verify attempts are incrementing
SELECT lesson_slug, attempts FROM lesson_progress WHERE user_id = '<test_user>' ORDER BY completed_at DESC LIMIT 5;

-- Verify bonus transactions appear
SELECT reason, amount, lesson_slug, created_at FROM xp_transactions WHERE user_id = '<test_user>' ORDER BY created_at DESC LIMIT 10;

-- Verify interaction events are captured
SELECT event_type, metadata, created_at FROM interaction_events WHERE user_id = '<test_user>' ORDER BY created_at DESC LIMIT 20;
```

**Healthy signals:**
- `xp_transactions` rows with `reason = 'first_attempt_bonus'` appear after first completions
- `interaction_events` rows accumulate during gameplay
- `lesson_progress.attempts` = 1 after first completion, increments on replay

**Failure signals:**
- No `first_attempt_bonus` rows despite new completions → check `award_xp` RPC logs
- Console errors `[completeLesson] first-attempt bonus failed` or `comeback bonus failed` → non-fatal but investigate
- `interaction_events` table missing → migration 006 not applied; event logging degrades silently

**Validation window:** First 2–3 lesson completions after deploy. Owner: @johnblythe.
