### PR TITLE
feat(cosmetics): avatar class evolution, realm titles, tier glows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to KidKode will be documented here.
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-07
+
+### Added
+- Avatar now shows kid's actual hero class emoji instead of hardcoded 🧙 (#37)
+- Avatar card gains tier-based border/glow styling — tier 1 (L1–4), tier 2 (L5–9, purple glow), tier 3 (L10+, gold glow) (#37)
+- Hero class evolves at L5 and L10 — evolved class name shown below hero name on dashboard (#37)
+- "EVOLVED!" card on UnlockScreen when lesson completion crosses a class evolution threshold (#37)
+- Realm titles earned on completing each of the 6 realms — shown as tappable badge on dashboard; tap cycles through earned titles (#37)
+- "NEW TITLE!" card on UnlockScreen when a realm badge is awarded (#37)
+- `active_title` column on `character_stats` (migration 007) — persists the kid's active title choice (#37)
+- `setActiveTitle` server action — validates against earned titles before persisting (#37)
+- `lib/classes.ts` — single source of truth for `CHARACTER_CLASSES`, `CLASS_EVOLUTIONS`, `REALM_TITLES`, and helpers (#37)
+
+### Changed
+- `PlayerProfile` — `heroClass` tightened from `string` to `HeroClass`; added `avatarTier`, `evolvedClassName`, `activeTitle`, `availableTitles` (#37)
+- `LessonCompletionResult` — added optional `classEvolved` and `newTitle` fields (#37)
+- `checkAndAwardBadges()` — now also auto-sets `active_title` on realm completion (non-fatal), returns `{ badges, newTitle }` (#37)
+- `completeLesson()` — detects class evolution threshold crossing (non-fatal); propagates `newTitle` from badge award (#37)
+- `UnlockScreen` — evolution and new-title cards added; delay sequence renumbered for all bonus cards (#37)
+- `app/onboard/page.tsx` and `app/parent/page.tsx` — now import `CHARACTER_CLASSES` from `lib/classes.ts` (#37)
+
 ## [1.2.0] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to KidKode will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+- `getProfile` fallback stats query error now logged — prevents silent Level 1 regression when DB retry fails (#37)
+- `completeLesson` `hero_class` pre-read error now logged — evolution detection no longer silently skips without a trace (#37)
+- `getProfile` `lesson_progress` fetch error now logged — empty lesson list no longer returned silently (#37)
+- `setActiveTitle` now returns `{ ok, reason }` discriminated union; client rolls back optimistic title update on failure (#37)
+- `checkAndAwardBadges` missing `REALM_TITLES`/`REALM_BADGES` entries now log as `error` instead of `warn` (#37)
+- `REALM_BADGES` config lookup null-guarded in `checkAndAwardBadges` and `getBadgesForUser` — prevents buried TypeError (#37)
+
 ## [1.3.0] - 2026-04-07
 
 ### Added

--- a/app/actions/progress.ts
+++ b/app/actions/progress.ts
@@ -9,6 +9,7 @@ import {
   completeLesson as _completeLesson,
   checkAndUnlockNextLesson as _checkAndUnlockNextLesson,
   loadDashboard as _loadDashboard,
+  setActiveTitle as _setActiveTitle,
 } from "@/lib/progress";
 import type { LessonProgressPatch, LessonCompletionResult, PlayerProfile } from "@/lib/types";
 
@@ -39,4 +40,8 @@ export async function checkAndUnlockNextLesson(userId: string): Promise<void> {
 
 export async function loadDashboard(userId: string): Promise<PlayerProfile | null> {
   return _loadDashboard(userId);
+}
+
+export async function setActiveTitle(userId: string, title: string): Promise<void> {
+  return _setActiveTitle(userId, title);
 }

--- a/app/actions/progress.ts
+++ b/app/actions/progress.ts
@@ -42,6 +42,6 @@ export async function loadDashboard(userId: string): Promise<PlayerProfile | nul
   return _loadDashboard(userId);
 }
 
-export async function setActiveTitle(userId: string, title: string): Promise<void> {
+export async function setActiveTitle(userId: string, title: string): Promise<{ ok: true } | { ok: false; reason: string }> {
   return _setActiveTitle(userId, title);
 }

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -223,7 +223,7 @@ export async function listChildren(parentId: string): Promise<PlayerProfile[]> {
       badges,
       avatarTier: getAvatarTier(level),
       evolvedClassName: getEvolvedClassName(heroClass, level),
-      activeTitle: null,
+      activeTitle: null, // intentionally omitted — parent dashboard does not display active titles
       availableTitles: getAvailableTitles(badges),
     };
   });

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -12,6 +12,9 @@ import type {
   HeroClass,
 } from "@/lib/types";
 import { lessons } from "@/content/lessons";
+import { getAvatarTier, getEvolvedClassName, getAvailableTitles } from "@/lib/classes";
+
+const KNOWN_HERO_CLASSES: HeroClass[] = ["wizard", "knight", "elf", "ninja", "hero", "merfolk"];
 
 // ============================================================
 // lookupUser — email → profile (discriminated union return)
@@ -199,20 +202,29 @@ export async function listChildren(parentId: string): Promise<PlayerProfile[]> {
     const completed = lessonRows.filter((r) => r.status === "completed").length;
     const levelInfo = calculateLevel(totalXp);
 
+    const heroClass = (KNOWN_HERO_CLASSES.includes(child.hero_class as HeroClass)
+      ? child.hero_class
+      : "wizard") as HeroClass;
+    const level = stats?.current_level ?? 1;
+    const badges = badgesByChild.get(child.id) ?? [];
     return {
       id: child.id,
       email: child.email,
       name: child.hero_name,
-      heroClass: child.hero_class,
+      heroClass,
       role: "child" as const,
-      level: stats?.current_level ?? 1,
+      level,
       xp: levelInfo.xp,
       xpToNextLevel: levelInfo.xpToNextLevel,
       streak: stats?.streak_days ?? 0,
       totalLessonsCompleted: completed,
       unlockedToday: false,
       lessons: lessonsMap,
-      badges: badgesByChild.get(child.id) ?? [],
+      badges,
+      avatarTier: getAvatarTier(level),
+      evolvedClassName: getEvolvedClassName(heroClass, level),
+      activeTitle: null,
+      availableTitles: getAvailableTitles(badges),
     };
   });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -249,6 +249,25 @@ body {
 }
 
 /* ============================================
+   Avatar Tiers — border/glow intensity per level milestone
+   Tier 1: base (L1–4), Tier 2: evolved (L5–9), Tier 3: gold (L10+)
+   ============================================ */
+
+.avatar-tier-1 {
+  border: 2px solid var(--color-xp-purple-dim);
+}
+
+.avatar-tier-2 {
+  border: 2px solid var(--color-xp-purple-bright);
+  box-shadow: 0 0 12px rgba(192, 132, 252, 0.5);
+}
+
+.avatar-tier-3 {
+  border: 2px solid var(--color-gold);
+  box-shadow: 0 0 16px rgba(251, 191, 36, 0.6), 0 0 32px rgba(251, 191, 36, 0.2);
+}
+
+/* ============================================
    Level Badge
    ============================================ */
 

--- a/app/lesson/[slug]/page.tsx
+++ b/app/lesson/[slug]/page.tsx
@@ -53,6 +53,8 @@ export default function LessonPlayerPage() {
     newBadges?: { slug: string; name: string; icon: string }[];
     firstAttemptBonus?: { bonusXp: number };
     comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number };
+    classEvolved?: { from: string; to: string };
+    newTitle?: string;
   }>({
     xpEarned: 0,
     newLevel: 1,
@@ -172,6 +174,8 @@ export default function LessonPlayerPage() {
             newBadges: result.newBadges,
             firstAttemptBonus: result.firstAttemptBonus,
             comebackBonus: result.comebackBonus,
+            classEvolved: result.classEvolved,
+            newTitle: result.newTitle,
           });
         } catch (err) {
           console.error("[LessonPlayer] completeLesson error:", err);
@@ -256,6 +260,8 @@ export default function LessonPlayerPage() {
         newBadges={unlockData.newBadges}
         firstAttemptBonus={unlockData.firstAttemptBonus}
         comebackBonus={unlockData.comebackBonus}
+        classEvolved={unlockData.classEvolved}
+        newTitle={unlockData.newTitle}
       />
     );
   }

--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -5,16 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { createUser } from "@/app/actions/users";
 import { useActiveUser } from "@/lib/hooks/useActiveUser";
-import type { HeroClass } from "@/lib/types";
-
-const CHARACTER_CLASSES: { emoji: string; label: string; value: HeroClass }[] = [
-  { emoji: "🧙", label: "Wizard", value: "wizard" },
-  { emoji: "🪖", label: "Knight", value: "knight" },
-  { emoji: "🧝", label: "Elf", value: "elf" },
-  { emoji: "🥷", label: "Ninja", value: "ninja" },
-  { emoji: "🦸", label: "Hero", value: "hero" },
-  { emoji: "🧜", label: "Merfolk", value: "merfolk" },
-];
+import { CHARACTER_CLASSES } from "@/lib/classes";
 
 const MAX_NAME_LENGTH = 20;
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -413,7 +413,7 @@ export default function DashboardPage() {
     router.push("/login");
   }
 
-  function handleTitleCycle() {
+  async function handleTitleCycle() {
     if (!profile || !userId) return;
     const { availableTitles, activeTitle } = profile;
     if (availableTitles.length <= 1) return;
@@ -424,8 +424,12 @@ export default function DashboardPage() {
     // Optimistic update
     setProfile((prev) => prev ? { ...prev, activeTitle: nextTitle } : prev);
 
-    // Persist in background — fire-and-forget
-    void setActiveTitle(userId, nextTitle);
+    // Persist — roll back optimistic update on failure
+    const result = await setActiveTitle(userId, nextTitle);
+    if (!result.ok) {
+      console.error("[handleTitleCycle] title persist failed — rolling back:", result.reason);
+      setProfile((prev) => prev ? { ...prev, activeTitle } : prev);
+    }
   }
 
   // Loading (before hydration or while fetching)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,11 @@ import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { lessons } from "@/content/lessons";
-import { loadDashboard } from "@/app/actions/progress";
+import { loadDashboard, setActiveTitle } from "@/app/actions/progress";
 import { useActiveUser } from "@/lib/hooks/useActiveUser";
 import type { PlayerProfile, LessonProgress } from "@/lib/types";
 import { getQuizTier, getComebackMultiplier } from "@/lib/types";
+import { CHARACTER_CLASSES } from "@/lib/classes";
 import VolumeToggle from "@/components/VolumeToggle";
 import { useAudio } from "@/lib/audio/AudioContext";
 import BadgeWall from "@/components/BadgeWall";
@@ -43,10 +44,15 @@ function XpBar({ xp, xpToNextLevel }: { xp: number; xpToNextLevel: number }) {
 function PlayerHeader({
   profile,
   onSignOut,
+  onTitleCycle,
 }: {
   profile: PlayerProfile;
   onSignOut: () => void;
+  onTitleCycle: () => void;
 }) {
+  const heroEmoji =
+    CHARACTER_CLASSES.find((c) => c.value === profile.heroClass)?.emoji ?? "🧙";
+
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
@@ -57,20 +63,40 @@ function PlayerHeader({
       <div className="flex flex-col sm:flex-row sm:items-center gap-4">
         {/* Avatar & Name */}
         <div className="flex items-center gap-3 flex-1">
-          <div className="w-14 h-14 rounded-lg bg-void-lighter border border-xp-purple-dim flex items-center justify-center text-3xl">
-            <span className="float">🧙</span>
+          <div
+            className={`w-14 h-14 rounded-lg bg-void-lighter flex items-center justify-center text-3xl avatar-tier-${profile.avatarTier}`}
+          >
+            <span className="float">{heroEmoji}</span>
           </div>
           <div>
             <h1 className="text-xl font-bold text-gold font-[family-name:var(--font-pixel)] text-glow-gold">
               {profile.name}
             </h1>
-            <div className="flex items-center gap-2 mt-1">
+            {/* Evolved class name subtitle */}
+            {profile.role === "child" && (
+              <div className="text-xs text-xp-purple-bright mt-0.5">{profile.evolvedClassName}</div>
+            )}
+            <div className="flex items-center gap-2 mt-1 flex-wrap">
               <span className="level-badge">LVL {profile.level}</span>
               {profile.streak > 0 && (
                 <span className="flex items-center gap-1 text-sm text-fire-orange">
                   <span className="streak-fire">🔥</span>
                   {profile.streak} day streak
                 </span>
+              )}
+              {/* Realm title badge — child-only, tappable when 2+ titles */}
+              {profile.role === "child" && profile.activeTitle && (
+                <button
+                  onClick={profile.availableTitles.length > 1 ? onTitleCycle : undefined}
+                  className={`text-xs px-2 py-0.5 rounded-full border border-gold/40 text-gold bg-gold/10 font-medium ${
+                    profile.availableTitles.length > 1
+                      ? "cursor-pointer hover:bg-gold/20 transition-colors"
+                      : "cursor-default"
+                  }`}
+                  title={profile.availableTitles.length > 1 ? "Tap to cycle titles" : undefined}
+                >
+                  {profile.activeTitle}
+                </button>
               )}
             </div>
           </div>
@@ -387,6 +413,21 @@ export default function DashboardPage() {
     router.push("/login");
   }
 
+  function handleTitleCycle() {
+    if (!profile || !userId) return;
+    const { availableTitles, activeTitle } = profile;
+    if (availableTitles.length <= 1) return;
+
+    const currentIdx = activeTitle ? availableTitles.indexOf(activeTitle) : -1;
+    const nextTitle = availableTitles[(currentIdx + 1) % availableTitles.length];
+
+    // Optimistic update
+    setProfile((prev) => prev ? { ...prev, activeTitle: nextTitle } : prev);
+
+    // Persist in background — fire-and-forget
+    void setActiveTitle(userId, nextTitle);
+  }
+
   // Loading (before hydration or while fetching)
   if (!mounted || !userId || (!profile && isPending)) {
     return (
@@ -434,7 +475,7 @@ export default function DashboardPage() {
       </motion.div>
 
       {/* Player Header */}
-      <PlayerHeader profile={profile} onSignOut={handleSignOut} />
+      <PlayerHeader profile={profile} onSignOut={handleSignOut} onTitleCycle={handleTitleCycle} />
 
       {/* Comeback Banner — child only, 3+ days away */}
       {profile.role === "child" && (profile.daysAway ?? 0) >= 3 && (

--- a/app/parent/page.tsx
+++ b/app/parent/page.tsx
@@ -7,17 +7,8 @@ import Link from "next/link";
 import { useActiveUser } from "@/lib/hooks/useActiveUser";
 import { listChildren, createChild } from "@/app/actions/users";
 import { getProfile } from "@/app/actions/progress";
-import type { PlayerProfile, HeroClass } from "@/lib/types";
-
-const CHARACTER_CLASSES: { emoji: string; label: string; value: HeroClass }[] =
-  [
-    { emoji: "🧙", label: "Wizard", value: "wizard" },
-    { emoji: "🪖", label: "Knight", value: "knight" },
-    { emoji: "🧝", label: "Elf", value: "elf" },
-    { emoji: "🥷", label: "Ninja", value: "ninja" },
-    { emoji: "🦸", label: "Hero", value: "hero" },
-    { emoji: "🧜", label: "Merfolk", value: "merfolk" },
-  ];
+import type { PlayerProfile } from "@/lib/types";
+import { CHARACTER_CLASSES } from "@/lib/classes";
 
 export default function ParentPage() {
   const router = useRouter();

--- a/components/UnlockScreen.tsx
+++ b/components/UnlockScreen.tsx
@@ -19,6 +19,8 @@ interface UnlockScreenProps {
   newBadges?: { slug: string; name: string; icon: string }[];
   firstAttemptBonus?: { bonusXp: number };
   comebackBonus?: { daysAway: number; multiplier: number; bonusXp: number };
+  classEvolved?: { from: string; to: string };
+  newTitle?: string;
 }
 
 function XPCounter({ target, duration = 2000 }: { target: number; duration?: number }) {
@@ -43,17 +45,20 @@ function XPCounter({ target, duration = 2000 }: { target: number; duration?: num
   return <span>{count}</span>;
 }
 
-export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizScore, newBadges, firstAttemptBonus, comebackBonus }: UnlockScreenProps) {
+export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizScore, newBadges, firstAttemptBonus, comebackBonus, classEvolved, newTitle }: UnlockScreenProps) {
   const { sfx, playBGM } = useAudio();
   const reducedMotion = useReducedMotion();
   const [showContent, setShowContent] = useState(false);
   const [showStats, setShowStats] = useState(false);
   const [showButton, setShowButton] = useState(false);
+  // Counter key for AnimatePresence — prevents stale boolean toggle when same screen fires back-to-back
+  const [statsKey, setStatsKey] = useState(0);
   const tier = getQuizTier(quizScore);
 
   useEffect(() => {
     sfx("unlock-celebration");
     playBGM("victory");
+    setStatsKey((k) => k + 1);
     const t1 = setTimeout(() => setShowContent(true), 300);
     const t2 = setTimeout(() => setShowStats(true), 1500);
     const t3 = setTimeout(() => setShowButton(true), 2800);
@@ -139,7 +144,8 @@ export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizSco
           )}
         </AnimatePresence>
 
-        <AnimatePresence>
+        {/* Stats cards — keyed counter prevents stale AnimatePresence on back-to-back completions */}
+        <AnimatePresence key={statsKey}>
           {showStats && (
             <motion.div
               initial={{ opacity: 0, y: 30 }}
@@ -184,97 +190,141 @@ export default function UnlockScreen({ xpEarned, newLevel, streak, slug, quizSco
                 </div>
               </motion.div>
 
-              {/* Streak */}
-              {streak > 0 && (
+              {/* Class Evolved — slot after Level, before Streak */}
+              {classEvolved && (
                 <motion.div
-                  initial={{ scale: 0.8 }}
-                  animate={{ scale: 1 }}
+                  initial={{ scale: 0.5, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
                   transition={{ type: "spring", stiffness: 200, delay: 0.3 }}
                   className="rpg-card px-6 py-4 flex items-center justify-between"
-                  style={{
-                    boxShadow: "0 0 12px rgba(239,68,68,0.15)",
-                  }}
-                >
-                  <span className="text-slate-400 text-sm uppercase tracking-wider">
-                    Streak
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <span className="streak-fire text-2xl">&#128293;</span>
-                    <span className="text-fire-orange font-bold text-xl">{streak} day{streak > 1 ? "s" : ""}</span>
-                  </div>
-                </motion.div>
-              )}
-
-              {/* Score Tier */}
-              {tier && (
-                <motion.div
-                  initial={{ scale: 0.8 }}
-                  animate={{ scale: 1 }}
-                  transition={{ type: "spring", stiffness: 200, delay: 0.45 }}
-                  className="rpg-card px-6 py-4 flex items-center justify-between"
-                >
-                  <span className="text-slate-400 text-sm uppercase tracking-wider">Score Tier</span>
-                  <QuizTierBadge tier={tier} size="md" />
-                </motion.div>
-              )}
-
-              {/* First Try! bonus */}
-              {firstAttemptBonus && (
-                <motion.div
-                  initial={{ scale: 0.5, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ type: "spring", stiffness: 200, delay: 0.6 }}
-                  className="rpg-card px-6 py-4 flex items-center justify-between border-gold/60"
-                  style={{ boxShadow: "0 0 20px rgba(251,191,36,0.4)" }}
-                >
-                  <span className="text-gold text-sm uppercase tracking-wider font-bold">First Try!</span>
-                  <div className="flex items-center gap-2">
-                    <span className="text-2xl font-black text-gold">+{firstAttemptBonus.bonusXp}</span>
-                    <span className="text-gold-dim text-sm">XP</span>
-                  </div>
-                </motion.div>
-              )}
-
-              {/* Welcome Back! comeback bonus */}
-              {comebackBonus && (
-                <motion.div
-                  initial={{ scale: 0.5, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ type: "spring", stiffness: 200, delay: firstAttemptBonus ? 0.75 : 0.6 }}
-                  className="rpg-card px-6 py-4 flex items-center justify-between"
-                  style={{ boxShadow: "0 0 20px rgba(249,115,22,0.35)", borderColor: "rgba(249,115,22,0.5)" }}
+                  style={{ boxShadow: "0 0 20px rgba(168,85,247,0.5)", borderColor: "rgba(168,85,247,0.6)" }}
                 >
                   <div className="flex flex-col">
-                    <span className="text-fire-orange text-sm uppercase tracking-wider font-bold">Welcome Back!</span>
-                    <span className="text-slate-500 text-xs">{comebackBonus.daysAway}d away → {comebackBonus.multiplier}x</span>
+                    <span className="text-xp-purple-bright text-sm uppercase tracking-wider font-bold">EVOLVED!</span>
+                    <span className="text-slate-400 text-xs">{classEvolved.from} → {classEvolved.to}</span>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-2xl font-black text-fire-orange">+{comebackBonus.bonusXp}</span>
-                    <span className="text-fire-orange/60 text-sm">XP</span>
-                  </div>
+                  <span className="text-2xl">✨</span>
                 </motion.div>
               )}
 
-              {/* New Badges */}
-              {newBadges && newBadges.length > 0 && newBadges.map((badge, i) => {
-                const bonusCardCount = (firstAttemptBonus ? 1 : 0) + (comebackBonus ? 1 : 0);
+              {/* New Title — slot after Class Evolved */}
+              {newTitle && (
+                <motion.div
+                  initial={{ scale: 0.5, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  transition={{ type: "spring", stiffness: 200, delay: classEvolved ? 0.45 : 0.3 }}
+                  className="rpg-card px-6 py-4 flex items-center justify-between"
+                  style={{ boxShadow: "0 0 20px rgba(251,191,36,0.35)", borderColor: "rgba(251,191,36,0.5)" }}
+                >
+                  <div className="flex flex-col">
+                    <span className="text-gold text-sm uppercase tracking-wider font-bold">NEW TITLE!</span>
+                    <span className="text-slate-400 text-xs">Now known as…</span>
+                  </div>
+                  <span className="text-gold font-bold text-sm">{newTitle}</span>
+                </motion.div>
+              )}
+
+              {/* Compute base delay offset for cards after the evolution slots */}
+              {(() => {
+                // Each extra card above (classEvolved, newTitle) shifts subsequent delays by 0.15
+                const evolutionOffset = (classEvolved ? 1 : 0) + (newTitle ? 1 : 0);
+
                 return (
-                  <motion.div
-                    key={badge.slug}
-                    initial={{ scale: 0.5, opacity: 0 }}
-                    animate={{ scale: 1, opacity: 1 }}
-                    transition={{ type: "spring", stiffness: 200, delay: 0.6 + bonusCardCount * 0.15 + i * 0.15 }}
-                    className="rpg-card px-6 py-4 flex items-center justify-between border-gold/40"
-                    style={{ boxShadow: "0 0 20px rgba(251,191,36,0.3)" }}
-                  >
-                    <span className="text-slate-400 text-sm uppercase tracking-wider">Realm Badge</span>
-                    <div className="flex items-center gap-2">
-                      <span className="text-2xl">{badge.icon}</span>
-                      <span className="text-gold font-bold text-sm">{badge.name}</span>
-                    </div>
-                  </motion.div>
+                  <>
+                    {/* Streak */}
+                    {streak > 0 && (
+                      <motion.div
+                        initial={{ scale: 0.8 }}
+                        animate={{ scale: 1 }}
+                        transition={{ type: "spring", stiffness: 200, delay: 0.3 + evolutionOffset * 0.15 }}
+                        className="rpg-card px-6 py-4 flex items-center justify-between"
+                        style={{
+                          boxShadow: "0 0 12px rgba(239,68,68,0.15)",
+                        }}
+                      >
+                        <span className="text-slate-400 text-sm uppercase tracking-wider">
+                          Streak
+                        </span>
+                        <div className="flex items-center gap-2">
+                          <span className="streak-fire text-2xl">&#128293;</span>
+                          <span className="text-fire-orange font-bold text-xl">{streak} day{streak > 1 ? "s" : ""}</span>
+                        </div>
+                      </motion.div>
+                    )}
+
+                    {/* Score Tier */}
+                    {tier && (
+                      <motion.div
+                        initial={{ scale: 0.8 }}
+                        animate={{ scale: 1 }}
+                        transition={{ type: "spring", stiffness: 200, delay: 0.45 + evolutionOffset * 0.15 }}
+                        className="rpg-card px-6 py-4 flex items-center justify-between"
+                      >
+                        <span className="text-slate-400 text-sm uppercase tracking-wider">Score Tier</span>
+                        <QuizTierBadge tier={tier} size="md" />
+                      </motion.div>
+                    )}
+
+                    {/* First Try! bonus */}
+                    {firstAttemptBonus && (
+                      <motion.div
+                        initial={{ scale: 0.5, opacity: 0 }}
+                        animate={{ scale: 1, opacity: 1 }}
+                        transition={{ type: "spring", stiffness: 200, delay: 0.6 + evolutionOffset * 0.15 }}
+                        className="rpg-card px-6 py-4 flex items-center justify-between border-gold/60"
+                        style={{ boxShadow: "0 0 20px rgba(251,191,36,0.4)" }}
+                      >
+                        <span className="text-gold text-sm uppercase tracking-wider font-bold">First Try!</span>
+                        <div className="flex items-center gap-2">
+                          <span className="text-2xl font-black text-gold">+{firstAttemptBonus.bonusXp}</span>
+                          <span className="text-gold-dim text-sm">XP</span>
+                        </div>
+                      </motion.div>
+                    )}
+
+                    {/* Welcome Back! comeback bonus */}
+                    {comebackBonus && (
+                      <motion.div
+                        initial={{ scale: 0.5, opacity: 0 }}
+                        animate={{ scale: 1, opacity: 1 }}
+                        transition={{ type: "spring", stiffness: 200, delay: (firstAttemptBonus ? 0.75 : 0.6) + evolutionOffset * 0.15 }}
+                        className="rpg-card px-6 py-4 flex items-center justify-between"
+                        style={{ boxShadow: "0 0 20px rgba(249,115,22,0.35)", borderColor: "rgba(249,115,22,0.5)" }}
+                      >
+                        <div className="flex flex-col">
+                          <span className="text-fire-orange text-sm uppercase tracking-wider font-bold">Welcome Back!</span>
+                          <span className="text-slate-500 text-xs">{comebackBonus.daysAway}d away → {comebackBonus.multiplier}x</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-2xl font-black text-fire-orange">+{comebackBonus.bonusXp}</span>
+                          <span className="text-fire-orange/60 text-sm">XP</span>
+                        </div>
+                      </motion.div>
+                    )}
+
+                    {/* New Badges */}
+                    {newBadges && newBadges.length > 0 && newBadges.map((badge, i) => {
+                      const bonusCardCount = (firstAttemptBonus ? 1 : 0) + (comebackBonus ? 1 : 0) + evolutionOffset;
+                      return (
+                        <motion.div
+                          key={badge.slug}
+                          initial={{ scale: 0.5, opacity: 0 }}
+                          animate={{ scale: 1, opacity: 1 }}
+                          transition={{ type: "spring", stiffness: 200, delay: 0.6 + bonusCardCount * 0.15 + i * 0.15 }}
+                          className="rpg-card px-6 py-4 flex items-center justify-between border-gold/40"
+                          style={{ boxShadow: "0 0 20px rgba(251,191,36,0.3)" }}
+                        >
+                          <span className="text-slate-400 text-sm uppercase tracking-wider">Realm Badge</span>
+                          <div className="flex items-center gap-2">
+                            <span className="text-2xl">{badge.icon}</span>
+                            <span className="text-gold font-bold text-sm">{badge.name}</span>
+                          </div>
+                        </motion.div>
+                      );
+                    })}
+                  </>
                 );
-              })}
+              })()}
             </motion.div>
           )}
         </AnimatePresence>

--- a/docs/plans/2026-04-07-001-feat-avatar-class-evolution-titles-plan.md
+++ b/docs/plans/2026-04-07-001-feat-avatar-class-evolution-titles-plan.md
@@ -1,0 +1,464 @@
+---
+title: "feat: Avatar upgrades, class evolution, name titles"
+type: feat
+status: completed
+date: 2026-04-07
+---
+
+# feat: Avatar upgrades, class evolution, name titles
+
+## Overview
+
+Add a cosmetic identity layer tied to level milestones and realm completion: (1) avatar display uses the kid's actual hero class emoji (currently hardcoded 🧙), with visual tier upgrades at level thresholds; (2) hero class evolves at level milestones with a celebratory UnlockScreen card; (3) kids earn a realm title suffix on dashboard after completing each realm, with tap-to-cycle selection.
+
+## Problem Frame
+
+The kid picks a hero class at onboarding (wizard, knight, elf, ninja, hero, merfolk) but the dashboard avatar ignores it — everyone sees 🧙. There's no visual reward for leveling up or completing realms beyond the XP number ticking up. This batch closes that gap with earned cosmetics that reinforce identity without requiring purchases.
+
+Philosophy: earn freedom progressively. Cosmetics should feel earned, not purchased. Realm titles are earned trophies; class evolution is a milestone reward.
+
+## Requirements Trace
+
+- R1. Dashboard avatar shows kid's actual hero class emoji, not a hardcoded wizard
+- R2. Avatar has 3 visual tiers (tier 1 = base, tier 2 = L5+, tier 3 = L10+) expressed as border/glow intensity on the avatar card
+- R3. Class evolves at L5 and L10 — new class name shown on dashboard and announced on UnlockScreen
+- R4. Each of the 6 realms grants a title suffix on completion; kid can cycle through earned titles on the dashboard
+- R5. Active title persisted to DB and auto-set to the newly earned title when a realm badge is awarded
+- R6. Class evolution detection is non-fatal — never blocks lesson completion
+- R7. `CHARACTER_CLASSES` extracted to `lib/` to eliminate duplication across `onboard/` and `parent/`
+
+## Scope Boundaries
+
+- No pixel art assets — emoji-based only in this batch; art upgrade is a future concern
+- No purchase or unlock mechanism — all cosmetics are earned, never bought
+- No parent-visible title/evolution UI in this batch — parent dashboard unchanged
+- Title cycling is tap-to-advance (circular), not a full picker modal
+- No second class branch or class-change mechanic — evolution is linear per class
+- No sound effect additions — reuse existing `sfx()` calls; new sounds are separate work
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/types.ts:248` — `HeroClass` union type; `PlayerProfile.heroClass` currently typed `string`
+- `supabase/migrations/001_init.sql` — `users.hero_class TEXT CHECK(...)` with 6 values
+- `character_stats` schema — `total_xp, current_level, streak_days, last_active_at, last_session_date` — no title or evolution fields
+- `app/page.tsx:43–111` — `PlayerHeader` component; avatar slot hardcodes 🧙, ignores `profile.heroClass`
+- `app/onboard/page.tsx:10–17` — class emoji/label map (duplicated)
+- `app/parent/page.tsx:12` — same class emoji/label map (duplicated)
+- `lib/types.ts:251–285` — `XP_PER_LEVEL` array + `calculateLevel()` — level thresholds live here
+- `lib/progress.ts` — `completeLesson()` orchestration; pre-read block at top extends to new columns
+- `lib/badges.ts` — `checkAndAwardBadges()` — realm completion detection; title auto-set hooks here
+- `components/UnlockScreen.tsx` — animated stat cards; `motion.div` + `rpg-card` + sequential delay pattern
+- `content/realms.ts` — 6 realm definitions with slugs: `apprentices-tower`, `scribes-library`, `frontend-realm`, `backend-dungeons`, `artificers-workshop`, `grand-quest`
+
+### Institutional Learnings
+
+- **Non-fatal side-effects** (`docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md`): All evolution detection and title-set calls added to `completeLesson()` must be individually wrapped in `try/catch`. Never add them to `Promise.all` with critical writes. Migration-gated columns (new `active_title`) are especially dangerous — migration may not be applied in all environments.
+- **Pre-read pattern** (`docs/solutions/best-practices/pre-read-pattern-before-transactional-writes-2026-04-07.md`): Level pre-read for evolution threshold detection must extend the existing `Promise.all` pre-read block at the top of `completeLesson()`, before any writes.
+- **AnimatePresence counter key** (`docs/solutions/ui-bugs/animate-presence-boolean-toggle-no-retrigger.md`): Evolution card on UnlockScreen must use a counter key, not a boolean, if it can fire on back-to-back completions.
+- **Data state vs VFX timing** (`docs/solutions/ui-bugs/boss-battle-hp-desynced-from-answer-flash.md`): Update `currentClass` / `currentTitle` state immediately; put fanfare into the delay only.
+
+## Key Technical Decisions
+
+- **Evolved class is computed, not stored**: `getEvolvedClassName(heroClass, level)` derives the display name at render time from `hero_class` (stored) + `current_level` (stored). No new DB column — avoids a migration and a write on every level-up.
+- **Avatar tier is computed from level**: `getAvatarTier(level)` → 1/2/3. Applied as CSS class (`avatar-tier-1/2/3`) — border width and glow color change per tier. No DB storage.
+- **Active title requires storage**: `active_title TEXT` on `character_stats` (nullable). Computed titles could drift if realm data changes; persisting the active choice is safer and enables future picker UI.
+- **Title auto-set on badge award**: `checkAndAwardBadges()` already detects realm completion and inserts `user_badges`. Extend it to also `UPDATE character_stats SET active_title = <new title>` non-fatally — natural home, no new call site.
+- **Title cycle via server action**: Tapping the title on the dashboard calls a new `setActiveTitle(userId, title)` server action — thin wrapper over a single UPDATE. Optimistic UI update on the client.
+- **`CHARACTER_CLASSES` extracted to `lib/classes.ts`**: Needed by both server-side badge/title logic and client-side rendering. Single source of truth.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Store evolved class?** No — computed from existing `hero_class` + `current_level`. Zero migration risk.
+- **Title storage location?** `character_stats` (not `users`) — `character_stats` is the mutable progression table; `users` holds identity. Consistent with streak, level, XP.
+- **Realm structure ready?** Yes — issue #41 closed; `content/realms.ts` has all 6 realms.
+- **Level thresholds for evolution?** Two tiers: first evolution at L5, second at L10. Matches the existing 15-level ladder without too-early or too-late payoffs. Defined as constants in `lib/classes.ts`.
+
+### Deferred to Implementation
+
+- **Evolved class names**: All six classes resolved:
+  - Wizard: L5→Mage, L10→Archmage
+  - Knight: L5→Warrior, L10→Paladin
+  - Elf: L5→Ranger, L10→Sylvan Sage
+  - Ninja: L5→Shinobi, L10→Shadow Master
+  - Hero: L5→Champion, L10→Legend
+  - Merfolk: L5→Tide Caller, L10→Sea Sovereign
+- **Exact CSS for tier glow**: Avatar tier border/glow values (`avatar-tier-2`, `avatar-tier-3`) are design decisions — implementer uses existing `xp-purple`, `gold-accent` tokens.
+- **Title text per realm**: Implementer defines in `lib/classes.ts` alongside realm slugs from `content/realms.ts`. Issue lists examples: "Git Guardian", "Terminal Sage", "Database Oracle".
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+lib/classes.ts (new)
+  CHARACTER_CLASSES[]       ← extracted from onboard + parent pages
+  CLASS_EVOLUTIONS{}        ← { heroClass: [{ level: 5, name }, { level: 10, name }] }
+  REALM_TITLES{}            ← { realmSlug: "Title Suffix" }
+  getAvatarTier(level)      → 1 | 2 | 3
+  getEvolvedClassName(...)  → display string
+  getAvailableTitles(badges[]) → string[]
+
+character_stats (DB)
+  + active_title TEXT       ← new column (migration 007)
+
+PlayerProfile (type)
+  heroClass: HeroClass      ← tighten from string
+  avatarTier: 1|2|3         ← computed, added to profile
+  evolvedClassName: string  ← computed, added to profile
+  activeTitle?: string      ← from character_stats.active_title
+  availableTitles: string[] ← derived from user_badges at load time
+
+completeLesson() flow
+  pre-read: [...existing, + current_level]  ← add to existing Promise.all (not currently fetched)
+  [... writes: award_xp (returns void — no level data), updateStreak ...]
+  post-write stats SELECT: already exists, provides newLevel (current_level after writes)
+  checkEvolution(preLevelForEvolution, newLevel) → non-fatal, returns classEvolved?
+  LessonCompletionResult += classEvolved?: { from, to }, newTitle?: string
+
+checkAndAwardBadges()
+  existing: insert user_badges
+  new (non-fatal): UPDATE character_stats SET active_title = REALM_TITLES[realmSlug]
+
+UnlockScreen
+  + classEvolved card (after Level card, before Score Tier)
+
+PlayerHeader (dashboard)
+  avatar: emoji from CHARACTER_CLASSES[heroClass] + tier CSS
+  title: activeTitle displayed below hero name, tap cycles
+```
+
+## Implementation Units
+
+- [x] **Unit 1: `lib/classes.ts` — shared class/title constants and helpers**
+
+**Goal:** Single source of truth for all hero class metadata, evolution tiers, realm titles, and derived display helpers.
+
+**Requirements:** R3, R4, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `lib/classes.ts`
+- Modify: `app/onboard/page.tsx` (import from lib instead of inline array)
+- Modify: `app/parent/page.tsx` (import from lib instead of inline array)
+- Test: `tests/classes.test.ts`
+
+**Approach:**
+- Export `CHARACTER_CLASSES` array matching current inline definitions (emoji, label, value per class)
+- Export `CLASS_EVOLUTIONS` — keyed by `HeroClass`, each entry is an ordered array of `{ level: number, name: string }` thresholds
+- Export `REALM_TITLES` — keyed by realm slug (matching `content/realms.ts`), value is title suffix string
+- Export `getAvatarTier(level: number): 1 | 2 | 3` — level < 5 = 1, level < 10 = 2, else 3
+- Export `getEvolvedClassName(heroClass: HeroClass, level: number): string` — returns current evolution name or base class label if no threshold crossed
+- Export `getAvailableTitles(badges: { slug: string }[]): string[]` — accepts `EarnedBadge[]` shape (field is `slug`, not `badge_slug`); maps to `REALM_TITLES` values, filters missing. **Note: `REALM_TITLES` must be typed `Record<string, string>` keyed by realm slug strings (e.g. `'apprentices-tower'`), NOT by `RealmId` numeric values — do not follow the `REALM_BADGES` pattern which uses numeric keys.**
+- `getEvolvedClassName` must handle an unrecognized `heroClass` gracefully — return the base class label string, not `undefined`, if the class is not found in `CLASS_EVOLUTIONS`. Never throw or return `undefined`.
+- Update `app/onboard/page.tsx` and `app/parent/page.tsx` to import from `lib/classes.ts`; behavior unchanged
+
+**Patterns to follow:**
+- `lib/types.ts:251–267` — `XP_PER_LEVEL` constant array pattern
+- `content/realms.ts` — realm slug naming conventions to match in `REALM_TITLES` keys (string slugs, not numeric IDs)
+
+**Test scenarios:**
+- Happy path: `getAvatarTier(1)` → 1; `getAvatarTier(4)` → 1; `getAvatarTier(5)` → 2; `getAvatarTier(9)` → 2; `getAvatarTier(10)` → 3; `getAvatarTier(15)` → 3
+- Happy path: `getEvolvedClassName("wizard", 4)` → base wizard label; `getEvolvedClassName("wizard", 5)` → "Archmage"; `getEvolvedClassName("wizard", 10)` → second evolution name
+- Happy path: `REALM_TITLES['apprentices-tower']` returns a non-undefined string
+- Happy path: `getAvailableTitles([{ slug: "apprentices-tower" }])` → array with that realm's title
+- Edge case: `getAvailableTitles([])` → empty array
+- Edge case: `getAvailableTitles([{ slug: "unknown-realm" }])` → empty array (no crash)
+- Edge case: `getEvolvedClassName("wizard", 0)` → base label (no negative or null tier)
+- Edge case: `getEvolvedClassName("unknownclass" as HeroClass, 5)` → returns a non-undefined string (safe fallback, no crash)
+
+**Verification:**
+- Onboard and parent pages render class options identically after refactor
+- All helper functions return correct values for boundary levels (4, 5, 9, 10)
+
+---
+
+- [x] **Unit 2: Migration 007 — `active_title` column**
+
+**Goal:** Persist the kid's active realm title to DB.
+
+**Requirements:** R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `supabase/migrations/007_active_title.sql`
+
+**Approach:**
+- `ALTER TABLE character_stats ADD COLUMN IF NOT EXISTS active_title TEXT DEFAULT NULL`
+- No backfill needed — existing users get `NULL`, which renders as "no title" on dashboard
+- Register in `supabase_migrations.schema_migrations` after applying
+- Apply via: `psql postgresql://postgres:postgres@localhost:55122/postgres -f supabase/migrations/007_active_title.sql`
+
+**Patterns to follow:**
+- `supabase/migrations/005_badges.sql` — header comment style, `IF NOT EXISTS` pattern
+
+**Test expectation:** none — pure DDL; verified by successful migration application and column existence check
+
+**Verification:**
+- Column `active_title TEXT` exists on `character_stats`
+- Existing rows have `NULL` for `active_title`
+- `UPDATE character_stats SET active_title = 'Git Guardian' WHERE user_id = ...` succeeds
+
+---
+
+- [x] **Unit 3: Extend `PlayerProfile` + `loadDashboard`**
+
+**Goal:** Surface avatar tier, evolved class name, active title, and available titles in the profile type used by dashboard and lesson page.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** Units 1, 2
+
+**Files:**
+- Modify: `lib/types.ts`
+- Modify: `lib/progress.ts` (rowsToProfile / loadDashboard)
+- Test: `tests/progress.test.ts`
+
+**Approach:**
+- Tighten `PlayerProfile.heroClass` from `string` to `HeroClass`
+- Add to `PlayerProfile`: `avatarTier: 1 | 2 | 3`, `evolvedClassName: string`, `activeTitle: string | null`, `availableTitles: string[]`
+- In `rowsToProfile`, compute `avatarTier` and `evolvedClassName` using helpers from `lib/classes.ts`. `badgeRows` is already in scope here — pass them to `getAvailableTitles()` to populate `availableTitles` (do NOT add a duplicate badge fetch in `loadDashboard`).
+- The SELECT in `getProfile` must be extended to include `active_title` from `character_stats`. A try/catch alone is insufficient — if the column is not in the SELECT, `stats.active_title` will always be `undefined` regardless of DB state. Wrap the SELECT extension itself in a try/catch so a missing column (migration not yet applied) silently returns `null` rather than crashing.
+- Add a runtime `HeroClass` type guard in `rowsToProfile` when mapping `user.hero_class` (typed `string` from DB): validate against the known values array and fall back to `'wizard'` if unrecognized. Do not use a blind `as HeroClass` cast.
+- `makeEmptyProfile` sets `heroClass: 'wizard'` — this is fine; ensure it uses the `HeroClass` type annotation after tightening.
+
+**Patterns to follow:**
+- Existing `daysAway` computation pattern in `loadDashboard` (added in PR #44) — same shape: read → compute → attach to profile
+- Pre-read non-fatal pattern for migration-gated columns
+
+**Test scenarios:**
+- Happy path: level 5 kid → `avatarTier === 2`, `evolvedClassName` reflects first evolution
+- Happy path: kid with 2 realm badges → `availableTitles.length === 2`
+- Happy path: `activeTitle` returns the stored value from `character_stats.active_title`
+- Edge case: `active_title` column missing (migration not applied) → `activeTitle === null`, no crash
+- Edge case: `heroClass` value not in `HeroClass` union (legacy data) → safe fallback to base label
+
+**Verification:**
+- `PlayerProfile` fields present and correctly typed
+- Dashboard renders with correct avatar tier and title for a test user
+
+---
+
+- [x] **Unit 4: Fix `PlayerHeader` avatar + title display**
+
+**Goal:** Dashboard profile card shows kid's actual hero class emoji with tier-based visual treatment and active realm title.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `app/page.tsx` (`PlayerHeader` component, lines 43–111)
+
+**Approach:**
+- Replace hardcoded `🧙` with `CHARACTER_CLASSES.find(c => c.value === profile.heroClass)?.emoji ?? '🧙'`
+- Apply `avatar-tier-{profile.avatarTier}` CSS class to the avatar container — tier 1 = current default border, tier 2 = brighter border, tier 3 = gold glow
+- Add `avatar-tier-1/2/3` utility classes to `globals.css` (or use Tailwind inline — whichever matches existing patterns)
+- Below the hero name, show `profile.evolvedClassName` as a subtitle line (replaces or supplements raw class label)
+- If `profile.activeTitle` exists, render it as a tappable badge next to the hero name — clicking advances to the next available title (circular, calls `setActiveTitle` server action)
+- Optimistic UI: update local state immediately on tap, server action runs in background (fire-and-forget)
+- If `profile.availableTitles.length <= 1`, title is not tappable (no cycling needed)
+
+**Patterns to follow:**
+- `ComebackBanner` in `app/page.tsx` — inline component definition pattern
+- `app/page.tsx:440–441` — conditional render with `profile.role === "child"` guard (title display is child-only)
+- Fire-and-forget server action pattern from `app/lesson/[slug]/page.tsx` (plain async, no `startTransition`)
+
+**Test scenarios:**
+- Happy path: knight kid at L1 → sees 🪖 with tier-1 border styling
+- Happy path: wizard kid at L5 → sees 🧙 with tier-2 border, "Archmage" subtitle
+- Happy path: kid with 1 realm title → title badge shown, tapping cycles (wraps back if only 1, no-op)
+- Happy path: kid with 2+ titles → tap cycles forward through `availableTitles`
+- Edge case: `heroClass` missing from `CHARACTER_CLASSES` map → falls back to 🧙, no crash
+- Edge case: `activeTitle === null` → no title badge rendered, no empty string shown
+- Edge case: parent account → no title badge (role guard)
+
+**Verification:**
+- Avatar emoji matches kid's chosen class
+- Tier-2 and tier-3 kids have visually distinct avatar card treatment
+- Title tap cycles to next title and persists after page reload
+
+---
+
+- [x] **Unit 5: `setActiveTitle` server action**
+
+**Goal:** Persist the kid's active title choice via a server action.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `app/actions/progress.ts`
+- Modify: `lib/progress.ts`
+- Test: `tests/progress.test.ts`
+
+**Approach:**
+- Add `setActiveTitle(userId: string, title: string): Promise<void>` to `lib/progress.ts` — single `UPDATE character_stats SET active_title = $title WHERE user_id = $userId`
+- Validate `title` against the user's earned titles: fetch `user_badges` for `userId` inside the server function, call `getAvailableTitles(badges)`, check that `title` is in the result. If not in the user's earned titles, no-op with `console.warn`. Do NOT validate against `Object.values(REALM_TITLES)` alone — a title must be earned, not just be a valid title string.
+- Add thin server action wrapper in `app/actions/progress.ts` with `"use server"` directive
+- Client calls fire-and-forget (no await in UI path)
+
+**Patterns to follow:**
+- `app/actions/events.ts` — thin `"use server"` delegation pattern
+- Existing single-row UPDATE patterns in `lib/progress.ts`
+
+**Test scenarios:**
+- Happy path: valid earned title → `character_stats.active_title` updated in DB
+- Edge case: title is a valid `REALM_TITLES` value but not earned by the user → no-op, no DB write, console.warn logged
+- Edge case: title not in user's available titles → no-op, no DB write, console.warn logged
+- Edge case: empty string title → no-op
+- Error path: DB update fails → function returns without throwing, error logged
+
+**Verification:**
+- `character_stats.active_title` reflects the new value after calling `setActiveTitle`
+- Invalid titles are rejected without DB writes
+
+---
+
+- [x] **Unit 6: Class evolution detection in `completeLesson()`**
+
+**Goal:** Detect when a lesson completion causes the player's level to cross an evolution threshold, surface it in `LessonCompletionResult`.
+
+**Requirements:** R3, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `lib/progress.ts`
+- Modify: `lib/types.ts`
+- Test: `tests/progress.test.ts`
+
+**Approach:**
+- **Pre-read**: `current_level` is NOT currently fetched in the existing `Promise.all` pre-read block (which selects only `last_session_date` from `character_stats`). Add `current_level` to that SELECT. Store as `preLevelForEvolution`. This is the baseline before any writes.
+- **Post-write level source**: `award_xp` RPC returns void — it does NOT return the new level. The new level is available from the existing post-write `character_stats` SELECT that already runs at the end of `completeLesson()`. Use that result's `current_level` as `newLevel`. Do NOT attempt to read level from `award_xp`'s return value.
+- Compute `oldEvolution = getEvolvedClassName(heroClass, preLevelForEvolution)` and `newEvolution = getEvolvedClassName(heroClass, newLevel)`.
+- If `oldEvolution !== newEvolution`, set `classEvolved = { from: oldEvolution, to: newEvolution }` in the result.
+- Entire detection block wrapped in its own try/catch — on failure, `classEvolved` is omitted, lesson completes normally.
+- Extend `LessonCompletionResult` with `classEvolved?: { from: string; to: string }`.
+
+**Patterns to follow:**
+- Existing `firstAttemptBonus` detection in `completeLesson()` — same pre-read + post-write compare shape
+- Non-fatal side-effect pattern from `docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md`
+
+**Test scenarios:**
+- Happy path: lesson completion takes player from L4 to L5 → `classEvolved` populated with correct from/to names
+- Happy path: lesson completion within same tier (L5→L6) → `classEvolved` is undefined
+- Happy path: both first-attempt bonus and class evolution in same completion → both fields present in result
+- Edge case: second evolution (L9→L10) → `classEvolved` reflects the second threshold
+- Edge case: pre-read of current_level fails → `classEvolved` omitted, lesson completes, no crash
+- Error path: evolution detection throws → caught, `classEvolved` undefined in result
+
+**Verification:**
+- `LessonCompletionResult.classEvolved` populated when level crosses L5 or L10
+- Lesson completion succeeds regardless of evolution detection failures
+
+---
+
+- [x] **Unit 7: UnlockScreen class evolution card**
+
+**Goal:** Show a celebration card on the unlock screen when the kid's class evolves.
+
+**Requirements:** R3
+
+**Dependencies:** Units 1, 6
+
+**Files:**
+- Modify: `components/UnlockScreen.tsx`
+- Modify: `app/lesson/[slug]/page.tsx` (pass `classEvolved` through to `unlockData`)
+
+**Approach:**
+- Extend `UnlockScreenProps` with `classEvolved?: { from: string; to: string }`
+- Pass `classEvolved` from `LessonCompletionResult` through `handleQuizComplete` → `unlockData` → `UnlockScreen`
+- New card slots after the Level card. Level is currently at delay `0.15`, Streak at `0.3`, Score Tier at `0.45`. Inserting the evolution card between Level and Streak shifts all subsequent hardcoded delays by `+0.15`. **Audit and renumber every hardcoded delay in `UnlockScreen.tsx` after insertion.** The badge delay formula also references `bonusCardCount` — extend it to include `classEvolved ? 1 : 0` to prevent badge cards overlapping with other bonus cards.
+- Card content: shows "EVOLVED!" label, `from → to` display, purple/gold accent.
+- Use counter key on the card's `AnimatePresence` wrapper (per `animate-presence-boolean-toggle-no-retrigger` learning).
+- Also extend `UnlockScreenProps` and `LessonCompletionResult` with `newTitle?: string` — pass through from `checkAndAwardBadges` (via the badge result) when a realm badge auto-sets a new title. Show a "NEW TITLE!" card on the UnlockScreen when `newTitle` is present so the kid knows their title changed before returning to the dashboard.
+- Play existing `sfx("level-up")` or equivalent on card reveal — reuse, don't add new SFX.
+
+**Patterns to follow:**
+- First-attempt bonus card in `UnlockScreen.tsx` — same `rpg-card` + `motion.div` + spring animation pattern
+- Counter key pattern from `docs/solutions/ui-bugs/animate-presence-boolean-toggle-no-retrigger.md`
+
+**Test scenarios:**
+- Happy path: `classEvolved` present → "EVOLVED!" card appears between Level and Score Tier cards
+- Happy path: `from → to` text shows both names correctly
+- Edge case: `classEvolved` absent → no extra card, existing layout unchanged
+- Edge case: back-to-back completions (replay immediately after evolution) → animation re-fires correctly via counter key
+
+**Verification:**
+- Visual: evolution card animates in at correct sequence position
+- Evolution card absent on normal completions with no threshold crossing
+- Layout intact with all bonus cards present simultaneously (first attempt + comeback + evolution)
+
+---
+
+- [x] **Unit 8: Auto-set title on realm badge award**
+
+**Goal:** When a realm badge is awarded, automatically set `active_title` to the newly earned realm's title.
+
+**Requirements:** R5
+
+**Dependencies:** Units 1, 2
+
+**Files:**
+- Modify: `lib/badges.ts`
+- Test: `tests/badges.test.ts`
+
+**Approach:**
+- In `checkAndAwardBadges()`, after inserting a new `user_badges` row, the loop variable is `realmId` (numeric `RealmId` 1–6). To get the slug, call `realms.find(r => r.id === realmId)?.slug` — this is the string slug that matches `REALM_TITLES` keys. Then call `REALM_TITLES[slug]` to get the title string.
+- Attempt `UPDATE character_stats SET active_title = <titleString>` — wrapped in its own try/catch (non-fatal).
+- Only fires when a badge is newly inserted (not on repeat calls for already-earned badge).
+- If `slug` is undefined or not in `REALM_TITLES`, log `console.warn` and skip the DB write — do not throw.
+- Return the `newTitle` string from `checkAndAwardBadges()` (add to its return type) so `completeLesson()` can include it in `LessonCompletionResult` for the UnlockScreen (see Unit 7).
+
+**Patterns to follow:**
+- Existing badge insert + try/catch pattern in `lib/badges.ts`
+- Non-fatal side-effect isolation from `docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md`
+
+**Test scenarios:**
+- Happy path: first time completing a realm → `character_stats.active_title` updated to that realm's title; `newTitle` returned from function
+- Happy path: completing a second realm → `active_title` updated to the new realm's title (overwrite previous); new `newTitle` returned
+- Edge case: `realmId` has no matching realm in `content/realms.ts` → no DB write, no crash, console.warn
+- Edge case: realm slug not in `REALM_TITLES` → no DB write, no crash, console.warn
+- Edge case: badge already previously earned (repeat call) → title update skipped, `newTitle` is undefined
+- Error path: title UPDATE fails → badge still inserted successfully, no crash propagation
+
+**Verification:**
+- `character_stats.active_title` matches the latest earned realm title after lesson completion
+- Badge award succeeds even when title update is unavailable
+- `newTitle` flows through to `LessonCompletionResult` and appears on UnlockScreen when realm is earned
+
+## System-Wide Impact
+
+- **Interaction graph:** `completeLesson()` gains pre-read extension + evolution detection (non-fatal). `checkAndAwardBadges()` gains title auto-set (non-fatal). `loadDashboard()` gains avatar tier, evolved name, title fields. `PlayerHeader` gains avatar + title rendering.
+- **Error propagation:** All new logic (evolution detection, title auto-set, title cycle) is non-fatal. No new failure mode can block lesson completion or badge award.
+- **State lifecycle risks:** Title auto-set on badge award overwrites previous title — intentional (latest realm = active). Kid can correct via cycle on dashboard. No irreversible state.
+- **API surface parity:** `LessonCompletionResult` gains optional `classEvolved`. `PlayerProfile` gains `avatarTier`, `evolvedClassName`, `activeTitle`, `availableTitles`. Both are backward-compatible additions (new optional fields).
+- **Unchanged invariants:** XP award, streak, badge insert, lesson unlock flow — all unchanged. New code adds parallel cosmetic side-effects only.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `active_title` column absent from SELECT if migration not applied | SELECT in `getProfile` must include `active_title`; wrap in try/catch so missing column returns `null` not a crash. |
+| `CHARACTER_CLASSES` refactor breaks onboard/parent class selection | Unit 1 is a pure extraction — behavior identical, just imported from lib. Verified by test scenarios. |
+| Evolution detection uses wrong level source | `award_xp` RPC returns void. New level must come from the post-write `character_stats` SELECT, not from RPC return value. Explicitly documented in Unit 6. |
+| `REALM_TITLES` keyed by number instead of string slug | Must be `Record<string, string>` keyed by realm slug. Documented explicitly in Unit 1. Distinct from `REALM_BADGES` which uses numeric `RealmId`. |
+| Title auto-overwrite discards kid's explicit choice silently | `newTitle` now surfaces on UnlockScreen via Unit 7 so the kid sees the change before returning to dashboard. |
+| `getAvailableTitles` badge field mismatch | Function signature uses `{ slug: string }[]` matching `EarnedBadge` type — not `{ badge_slug: string }[]`. Documented in Unit 1. |
+| `heroClass` type blind cast introduces runtime 'undefined' | Runtime type guard in `rowsToProfile` validates against known values, falls back to `'wizard'`. Documented in Unit 3. |
+| Emoji rendering differs across devices/OS versions | Acceptable — all existing emoji use follows same pattern. Not a regression. |
+
+## Sources & References
+
+- Related issue: #37
+- Key files: `lib/types.ts`, `lib/progress.ts`, `lib/badges.ts`, `app/page.tsx`, `components/UnlockScreen.tsx`
+- Learnings: `docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md`
+- Learnings: `docs/solutions/best-practices/pre-read-pattern-before-transactional-writes-2026-04-07.md`
+- Learnings: `docs/solutions/ui-bugs/animate-presence-boolean-toggle-no-retrigger.md`

--- a/docs/solutions/best-practices/server-action-error-handling-silent-failures-2026-04-07.md
+++ b/docs/solutions/best-practices/server-action-error-handling-silent-failures-2026-04-07.md
@@ -1,0 +1,233 @@
+---
+title: "Server Action Error Handling: Silent Failures, Fire-and-Forget, and Log Severity"
+date: 2026-04-07
+category: docs/solutions/best-practices
+module: server-actions
+problem_type: best_practice
+component: service_object
+severity: high
+applies_when:
+  - A server action has a multi-stage fetch (advanced query with column fallback)
+  - A Promise.all contains three or more reads added to incrementally over time
+  - A client component calls a server action and updates local state before awaiting
+  - A log message describes a missing config entry or unmapped key
+  - Code indexes into a typed const map using a runtime key inside a try/catch
+tags:
+  - error-handling
+  - server-actions
+  - silent-failure
+  - nextjs
+  - supabase
+  - rollback
+  - logging
+related_components:
+  - frontend_stimulus
+  - database
+---
+
+# Server Action Error Handling: Silent Failures, Fire-and-Forget, and Log Severity
+
+## Context
+
+PR #45 (`feat/avatar-class-evolution-titles`) review surfaced six error handling gaps in Next.js server actions backed by Supabase. No production failures — found in code review before merge. The issues cluster into four generalizable patterns that recur naturally as server actions grow more complex:
+
+1. Fallback query errors that are never checked
+2. Parallel pre-read errors that are partially checked (some branches missing)
+3. Optimistic UI updates backed by fire-and-forget mutations with no rollback
+4. `console.warn` used for config/code bugs that require source edits to fix
+
+These patterns are extensions of the isolation and safe-direction patterns documented in
+`non-fatal-side-effects-in-transaction-paths-2026-04-06.md` and
+`pre-read-pattern-before-transactional-writes-2026-04-07.md` — this doc adds
+the logging discipline and return-contract layer those docs do not cover.
+
+## Guidance
+
+### Pattern 1 — Every query result must have an error check, including fallbacks
+
+Multi-stage fetches (try advanced query, fall back to simpler) often have the fallback
+error check omitted. The fallback path feels "safe" because it was written to recover
+from something — but it can fail independently for unrelated reasons (network, RLS, auth).
+
+**Rule**: every `.data` / `.error` from a Supabase call must be followed by an error
+check before `.data` is used, including the fallback leg.
+
+```ts
+// WRONG — fallback error silently swallowed
+const statsBasic = await supabase.from("character_stats").select("total_xp, ...").maybeSingle();
+statsData = statsBasic.data ? { ...statsBasic.data, active_title: null } : null;
+
+// CORRECT
+const statsBasic = await supabase.from("character_stats").select("total_xp, ...").maybeSingle();
+if (statsBasic.error) {
+  console.error("[getProfile] fallback stats fetch also failed — profile will show zero stats:", statsBasic.error.message);
+}
+statsData = statsBasic.data ? { ...statsBasic.data, active_title: null } : null;
+```
+
+The same rule applies to every leg of a `Promise.all`. Adding a third pre-read to an
+existing `Promise.all` requires adding a third error check — do not leave any leg unchecked:
+
+```ts
+const [existingProgressResult, statsPreResult, userPreResult] = await Promise.all([...]);
+
+if (existingProgressResult.error) {
+  console.error("[completeLesson] attempts pre-read failed — assuming non-first attempt:", existingProgressResult.error.message);
+}
+if (statsPreResult.error) {
+  console.error("[completeLesson] stats pre-read failed — comeback bonus skipped:", statsPreResult.error.message);
+}
+if (userPreResult.error) {
+  // EASY TO MISS: third branch added later — must also have its error check
+  console.error("[completeLesson] hero_class pre-read failed — evolution detection skipped:", userPreResult.error.message);
+}
+```
+
+---
+
+### Pattern 2 — Fire-and-forget mutations require explicit rollback on failure
+
+Optimistic UI updates must be paired with rollback logic whenever the underlying server
+action can fail. Calling `void fn()` discards the result and makes rollback impossible.
+
+**Rule**: never call a mutation server action with `void` if the UI has already been
+updated optimistically. Always `await` the result, check it, and restore prior state
+on failure.
+
+The server action must return a typed discriminated union so the caller can branch:
+
+```ts
+// WRONG — void return hides success/failure from caller
+export async function setActiveTitle(userId: string, title: string): Promise<void>
+
+// CORRECT — caller can distinguish success from failure
+export async function setActiveTitle(
+  userId: string,
+  title: string
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  // ... validation and DB write ...
+  if (error) {
+    console.error("[setActiveTitle] DB update failed:", error.message);
+    return { ok: false, reason: error.message };
+  }
+  return { ok: true };
+}
+```
+
+Client side — capture the pre-update value BEFORE the optimistic update, then use it
+in the rollback:
+
+```ts
+async function handleTitleCycle() {
+  const { availableTitles, activeTitle } = profile; // capture current title before update
+  const nextTitle = availableTitles[(currentIdx + 1) % availableTitles.length];
+
+  // Optimistic update
+  setProfile((prev) => prev ? { ...prev, activeTitle: nextTitle } : prev);
+
+  // Persist — roll back on failure
+  const result = await setActiveTitle(userId, nextTitle);
+  if (!result.ok) {
+    console.error("[handleTitleCycle] title persist failed — rolling back:", result.reason);
+    setProfile((prev) => prev ? { ...prev, activeTitle } : prev); // restore `activeTitle`
+  }
+}
+```
+
+---
+
+### Pattern 3 — Config/code bugs must use `console.error`, not `console.warn`
+
+`console.warn` is for transient or expected conditions: optional data missing, degraded-but-
+functional states, deprecation notices. It is not for conditions that require a source code
+change to fix.
+
+**Rule**: if the only resolution is editing a source file, use `console.error`. Include
+the specific file and the action required so the next developer has a starting point.
+
+```ts
+// WRONG — easy to miss, no actionable guidance
+console.warn(`No titles configured for realm ${realmSlug}`);
+
+// CORRECT — visible, actionable, points to the fix location
+console.error(
+  `[checkAndAwardBadges] REALM_TITLES missing entry for slug "${realmSlug}" — ` +
+  `title not awarded. Add this slug to lib/classes.ts REALM_TITLES.`
+);
+```
+
+---
+
+### Pattern 4 — Guard config lookups to prevent buried TypeErrors
+
+Unguarded indexing into a const map (`CONFIG[key]`) throws `TypeError: Cannot read
+properties of undefined` when the key is absent. Inside a try/catch, the root cause
+is replaced by a generic error message and the missing key is lost.
+
+**Rule**: always null-check config map lookups. Log with the missing key and fix
+location, then skip or return a safe default rather than throwing.
+
+```ts
+// WRONG — throws TypeError, root cause buried by outer try/catch
+const badges = toInsert.map((r) => ({
+  slug: r.badge_slug,
+  name: REALM_BADGES[r.realm_id].name,  // TypeError if realmId not in map
+  icon: REALM_BADGES[r.realm_id].icon,
+}));
+
+// CORRECT — missing key caught explicitly, logged actionably, entry skipped
+const badges = toInsert.flatMap((r) => {
+  const meta = REALM_BADGES[r.realm_id as RealmId];
+  if (!meta) {
+    console.error(
+      `[checkAndAwardBadges] REALM_BADGES missing entry for realm_id ${r.realm_id} ` +
+      `— Add to lib/badge-config.ts.`
+    );
+    return [];
+  }
+  return [{ slug: r.badge_slug, name: meta.name, icon: meta.icon }];
+});
+```
+
+## Why This Matters
+
+**Unlogged fallback errors** produce silent zero-state: the user sees blank stats or an
+empty lesson list with no error visible anywhere. Debugging starts from the wrong end —
+"why is the profile empty?" instead of "DB retry failed with RLS error at 14:32."
+
+**Fire-and-forget with optimistic UI** causes ghost state: the UI shows a change that
+did not persist. The user earns a title, taps to set it, sees it update — then next
+login it is gone. In a gamification context, earned state (titles, badges, level) must
+be reliable; silent reversion erodes trust.
+
+**`warn` for code bugs** lets config gaps survive development. Developers filter out
+warnings habitually. An error demands attention. A missing config entry is not a data
+state — it is a gap that requires a commit to fix.
+
+**Buried TypeErrors** obscure root cause. The outer catch logs "badge check failed" —
+correct but not helpful. The actual problem (a realm added to the DB without a matching
+`REALM_BADGES` entry) goes unfound until a second developer traces the stack manually.
+
+## When to Apply
+
+| Pattern | Apply when |
+|---------|-----------|
+| 1 — Every query has an error check | Multi-stage fetch exists; new read added to existing Promise.all |
+| 2 — No fire-and-forget mutations | Server action returns `void`; caller uses optimistic UI |
+| 3 — error vs warn for code bugs | Log describes missing config, unrecognized ID, or unmapped key |
+| 4 — Guard config lookups | Runtime key into `Record<K, V>` or typed const map, especially inside try/catch |
+
+## Examples
+
+All four patterns appeared together in PR #45. Affected files:
+- `lib/progress.ts` — Patterns 1 and 2 (fallback checks, parallel read checks, `setActiveTitle` return type)
+- `app/page.tsx` — Pattern 2 (optimistic rollback handler)
+- `lib/badges.ts` — Patterns 3 and 4 (warn→error, guarded config lookup)
+- `app/actions/progress.ts` — Pattern 2 (wrapper updated to match new return type)
+
+## Related
+
+- `docs/solutions/best-practices/non-fatal-side-effects-in-transaction-paths-2026-04-06.md` — isolation pattern this doc extends with logging discipline
+- `docs/solutions/best-practices/pre-read-pattern-before-transactional-writes-2026-04-07.md` — safe-direction defaults this doc extends with error log requirements
+- PR #45 — where these patterns were found and fixed
+- `lib/badge-config.ts` — the config map that must stay in sync when new realms are added

--- a/lib/badges.ts
+++ b/lib/badges.ts
@@ -6,6 +6,7 @@ import { lessons } from "@/content/lessons";
 import { realms } from "@/content/realms";
 import type { EarnedBadge, RealmId } from "@/lib/types";
 import { REALM_BADGES } from "@/lib/badge-config";
+import { REALM_TITLES } from "@/lib/classes";
 
 export { REALM_BADGES };
 
@@ -20,14 +21,20 @@ function lessonsByRealm(): Map<RealmId, string[]> {
   return map;
 }
 
+export interface BadgeAwardResult {
+  badges: { slug: string; name: string; icon: string }[];
+  newTitle?: string;
+}
+
 /**
  * Called after completeLesson(). Checks which realm badges the user has now
- * earned and inserts any missing ones. Returns slugs of newly awarded badges.
+ * earned and inserts any missing ones. Returns newly awarded badges and the
+ * latest auto-set realm title (if a new badge was earned).
  */
 export async function checkAndAwardBadges(
   userId: string,
   completedSlugs: Set<string>
-): Promise<{ slug: string; name: string; icon: string }[]> {
+): Promise<BadgeAwardResult> {
   const byRealm = lessonsByRealm();
 
   // Find realms where every lesson is completed
@@ -38,7 +45,7 @@ export async function checkAndAwardBadges(
     }
   }
 
-  if (completedRealmIds.length === 0) return [];
+  if (completedRealmIds.length === 0) return { badges: [] };
 
   // Fetch already-earned badges to avoid duplicates
   const { data: existing, error: existingError } = await supabase
@@ -59,16 +66,46 @@ export async function checkAndAwardBadges(
     })
     .filter((r): r is NonNullable<typeof r> => r !== null && !earnedSlugs.has(r.badge_slug));
 
-  if (toInsert.length === 0) return [];
+  if (toInsert.length === 0) return { badges: [] };
 
   const { error } = await supabase.from("user_badges").insert(toInsert);
   if (error) throw new Error(error.message);
 
-  return toInsert.map((r) => ({
+  // Auto-set active_title to the latest newly earned realm's title — non-fatal
+  // Uses the last inserted badge to reflect the most recent realm completed
+  let newTitle: string | undefined;
+  const lastInserted = toInsert[toInsert.length - 1];
+  try {
+    const realm = realms.find((r) => r.id === lastInserted.realm_id);
+    if (realm) {
+      const titleString = REALM_TITLES[realm.slug];
+      if (titleString !== undefined) {
+        const { error: titleError } = await supabase
+          .from("character_stats")
+          .update({ active_title: titleString })
+          .eq("user_id", userId);
+        if (titleError) {
+          console.warn("[checkAndAwardBadges] active_title update failed:", titleError.message);
+        } else {
+          newTitle = titleString;
+        }
+      } else {
+        console.warn(`[checkAndAwardBadges] no REALM_TITLES entry for slug "${realm.slug}" — skipping title update`);
+      }
+    } else {
+      console.warn(`[checkAndAwardBadges] no realm found for realmId ${lastInserted.realm_id} — skipping title update`);
+    }
+  } catch (err) {
+    console.error("[checkAndAwardBadges] title auto-set threw unexpectedly:", err);
+  }
+
+  const badges = toInsert.map((r) => ({
     slug: r.badge_slug,
     name: REALM_BADGES[r.realm_id as RealmId].name,
     icon: REALM_BADGES[r.realm_id as RealmId].icon,
   }));
+
+  return { badges, newTitle };
 }
 
 /**

--- a/lib/badges.ts
+++ b/lib/badges.ts
@@ -85,25 +85,28 @@ export async function checkAndAwardBadges(
           .update({ active_title: titleString })
           .eq("user_id", userId);
         if (titleError) {
-          console.warn("[checkAndAwardBadges] active_title update failed:", titleError.message);
+          console.error("[checkAndAwardBadges] active_title update failed:", titleError.message);
         } else {
           newTitle = titleString;
         }
       } else {
-        console.warn(`[checkAndAwardBadges] no REALM_TITLES entry for slug "${realm.slug}" — skipping title update`);
+        console.error(`[checkAndAwardBadges] REALM_TITLES missing entry for slug "${realm.slug}" — title not awarded. Add this slug to lib/classes.ts REALM_TITLES.`);
       }
     } else {
-      console.warn(`[checkAndAwardBadges] no realm found for realmId ${lastInserted.realm_id} — skipping title update`);
+      console.error(`[checkAndAwardBadges] realm not found for realmId ${lastInserted.realm_id} — badge inserted but title cannot be set. Check content/realms.ts and DB realm IDs.`);
     }
   } catch (err) {
     console.error("[checkAndAwardBadges] title auto-set threw unexpectedly:", err);
   }
 
-  const badges = toInsert.map((r) => ({
-    slug: r.badge_slug,
-    name: REALM_BADGES[r.realm_id as RealmId].name,
-    icon: REALM_BADGES[r.realm_id as RealmId].icon,
-  }));
+  const badges = toInsert.flatMap((r) => {
+    const meta = REALM_BADGES[r.realm_id as RealmId];
+    if (!meta) {
+      console.error(`[checkAndAwardBadges] REALM_BADGES missing entry for realm_id ${r.realm_id} — badge cannot be mapped. Add to lib/badge-config.ts.`);
+      return [];
+    }
+    return [{ slug: r.badge_slug, name: meta.name, icon: meta.icon }];
+  });
 
   return { badges, newTitle };
 }
@@ -121,16 +124,20 @@ export async function getBadgesForUser(userId: string): Promise<EarnedBadge[]> {
   if (error) throw new Error(error.message);
   if (!data) return [];
 
-  return data.map((row) => {
+  return data.flatMap((row) => {
     const realmId = row.realm_id as RealmId;
     const badge = REALM_BADGES[realmId];
-    return {
+    if (!badge) {
+      console.error(`[getBadgesForUser] REALM_BADGES missing entry for realm_id ${realmId} — skipping badge. Add to lib/badge-config.ts.`);
+      return [];
+    }
+    return [{
       slug: row.badge_slug,
       realmId,
       name: badge.name,
       icon: badge.icon,
       description: badge.description,
       earnedAt: row.earned_at,
-    };
+    }];
   });
 }

--- a/lib/classes.ts
+++ b/lib/classes.ts
@@ -87,6 +87,9 @@ export function getEvolvedClassName(heroClass: HeroClass, level: number): string
  * Accepts the EarnedBadge shape (slug field, not badge_slug).
  * Filters out slugs not found in REALM_TITLES.
  */
+// NOTE: badge.slug is expected to equal the realm's slug (set in checkAndAwardBadges → user_badges.badge_slug).
+// REALM_TITLES is keyed by realm slug. If non-realm badges are added in future,
+// this lookup will silently return no title for them — that is intentional.
 export function getAvailableTitles(badges: { slug: string }[]): string[] {
   const titles: string[] = [];
   for (const badge of badges) {

--- a/lib/classes.ts
+++ b/lib/classes.ts
@@ -1,0 +1,99 @@
+// Shared hero class metadata, evolution tiers, and realm title constants.
+// Single source of truth — imported by client components (onboard, parent, dashboard)
+// and server logic (badge/title award, evolution detection).
+
+import type { HeroClass } from "@/lib/types";
+
+// ============================================================
+// Character classes — matches DB CHECK constraint in migration 001
+// ============================================================
+
+export const CHARACTER_CLASSES: { emoji: string; label: string; value: HeroClass }[] = [
+  { emoji: "🧙", label: "Wizard",  value: "wizard" },
+  { emoji: "🪖", label: "Knight",  value: "knight" },
+  { emoji: "🧝", label: "Elf",     value: "elf" },
+  { emoji: "🥷", label: "Ninja",   value: "ninja" },
+  { emoji: "🦸", label: "Hero",    value: "hero" },
+  { emoji: "🧜", label: "Merfolk", value: "merfolk" },
+];
+
+// ============================================================
+// Class evolutions — ordered thresholds per hero class
+// First evolution at L5, second at L10
+// ============================================================
+
+export const CLASS_EVOLUTIONS: Record<HeroClass, Array<{ level: number; name: string }>> = {
+  wizard:  [{ level: 5, name: "Mage" },       { level: 10, name: "Archmage" }],
+  knight:  [{ level: 5, name: "Warrior" },    { level: 10, name: "Paladin" }],
+  elf:     [{ level: 5, name: "Ranger" },     { level: 10, name: "Sylvan Sage" }],
+  ninja:   [{ level: 5, name: "Shinobi" },    { level: 10, name: "Shadow Master" }],
+  hero:    [{ level: 5, name: "Champion" },   { level: 10, name: "Legend" }],
+  merfolk: [{ level: 5, name: "Tide Caller" }, { level: 10, name: "Sea Sovereign" }],
+};
+
+// ============================================================
+// Realm titles — keyed by realm slug (string), NOT by numeric RealmId
+// Must match slugs in content/realms.ts
+// ============================================================
+
+export const REALM_TITLES: Record<string, string> = {
+  "apprentices-tower":   "Tower Initiate",
+  "scribes-library":     "Code Scribe",
+  "frontend-realm":      "Web Weaver",
+  "backend-dungeons":    "Database Oracle",
+  "artificers-workshop": "Terminal Sage",
+  "grand-quest":         "Grand Champion",
+};
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/**
+ * Returns the avatar tier (1/2/3) based on current level.
+ * Tier 1: < 5, Tier 2: 5–9, Tier 3: 10+
+ */
+export function getAvatarTier(level: number): 1 | 2 | 3 {
+  if (level >= 10) return 3;
+  if (level >= 5) return 2;
+  return 1;
+}
+
+/**
+ * Returns the display name for the hero's current evolution at the given level.
+ * Falls back to the base class label if no threshold is crossed or class is unknown.
+ * Never returns undefined or throws.
+ */
+export function getEvolvedClassName(heroClass: HeroClass, level: number): string {
+  const evolutions = CLASS_EVOLUTIONS[heroClass];
+  if (!evolutions) {
+    // Unknown heroClass — return base label from CHARACTER_CLASSES, or class string as fallback
+    return CHARACTER_CLASSES.find((c) => c.value === heroClass)?.label ?? String(heroClass);
+  }
+
+  // Walk thresholds in reverse so the highest crossed threshold wins
+  for (let i = evolutions.length - 1; i >= 0; i--) {
+    if (level >= evolutions[i].level) {
+      return evolutions[i].name;
+    }
+  }
+
+  // No threshold crossed — return base class label
+  return CHARACTER_CLASSES.find((c) => c.value === heroClass)?.label ?? String(heroClass);
+}
+
+/**
+ * Returns the realm title strings available to a player based on their earned badges.
+ * Accepts the EarnedBadge shape (slug field, not badge_slug).
+ * Filters out slugs not found in REALM_TITLES.
+ */
+export function getAvailableTitles(badges: { slug: string }[]): string[] {
+  const titles: string[] = [];
+  for (const badge of badges) {
+    const title = REALM_TITLES[badge.slug];
+    if (title !== undefined) {
+      titles.push(title);
+    }
+  }
+  return titles;
+}

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -10,10 +10,18 @@ import type {
   LessonProgressPatch,
   LessonCompletionResult,
   EarnedBadge,
+  HeroClass,
 } from "@/lib/types";
 import { lessons } from "@/content/lessons";
 import { checkAndAwardBadges, getBadgesForUser } from "@/lib/badges";
 import type { NewlyAwardedBadge } from "@/lib/types";
+import { CHARACTER_CLASSES, getAvatarTier, getEvolvedClassName, getAvailableTitles } from "@/lib/classes";
+
+// Known HeroClass values for runtime type guard
+const KNOWN_HERO_CLASSES: HeroClass[] = ["wizard", "knight", "elf", "ninja", "hero", "merfolk"];
+function toHeroClass(raw: string): HeroClass {
+  return KNOWN_HERO_CLASSES.includes(raw as HeroClass) ? (raw as HeroClass) : "wizard";
+}
 
 // Factory function — never return a module-level default object.
 // Prevents singleton mutation across concurrent server requests.
@@ -32,6 +40,10 @@ export function makeEmptyProfile(userId: string, email: string): PlayerProfile {
     unlockedToday: false,
     lessons: {},
     badges: [],
+    avatarTier: 1,
+    evolvedClassName: CHARACTER_CLASSES.find((c) => c.value === "wizard")?.label ?? "Wizard",
+    activeTitle: null,
+    availableTitles: [],
   };
 }
 
@@ -50,6 +62,7 @@ function rowsToProfile(
     streak_days: number;
     last_session_date: string | null;
     last_active_at: string | null;
+    active_title?: string | null;
   } | null,
   lessonRows: Array<{
     lesson_slug: string;
@@ -90,13 +103,17 @@ function rowsToProfile(
       r.completed_at.startsWith(today)
   );
 
+  const heroClass = toHeroClass(user.hero_class);
+  const level = stats?.current_level ?? 1;
+  const availableTitles = getAvailableTitles(badgeRows);
+
   return {
     id: user.id,
     email: user.email,
     name: user.hero_name,
-    heroClass: user.hero_class,
+    heroClass,
     role: user.role as "parent" | "child",
-    level: stats?.current_level ?? 1,
+    level,
     xp: levelInfo.xp,
     xpToNextLevel: levelInfo.xpToNextLevel,
     streak: stats?.streak_days ?? 0,
@@ -105,6 +122,10 @@ function rowsToProfile(
     unlockedToday: completedToday,
     lessons: lessonsMap,
     badges: badgeRows,
+    avatarTier: getAvatarTier(level),
+    evolvedClassName: getEvolvedClassName(heroClass, level),
+    activeTitle: stats?.active_title ?? null,
+    availableTitles,
   };
 }
 
@@ -113,16 +134,11 @@ function rowsToProfile(
 // ============================================================
 
 export async function getProfile(userId: string): Promise<PlayerProfile | null> {
-  const [userResult, statsResult, progressResult] = await Promise.all([
+  const [userResult, progressResult] = await Promise.all([
     supabase
       .from("users")
       .select("id, email, hero_name, hero_class, role")
       .eq("id", userId)
-      .maybeSingle(),
-    supabase
-      .from("character_stats")
-      .select("total_xp, current_level, streak_days, last_session_date, last_active_at")
-      .eq("user_id", userId)
       .maybeSingle(),
     supabase
       .from("lesson_progress")
@@ -132,6 +148,27 @@ export async function getProfile(userId: string): Promise<PlayerProfile | null> 
 
   if (userResult.error) throw new Error(userResult.error.message);
   if (!userResult.data) return null;
+
+  // Stats SELECT includes active_title. If that column doesn't exist yet (migration not applied),
+  // PostgREST returns an error — fall back to selecting without it so core stats still load.
+  let statsData: Parameters<typeof rowsToProfile>[1] = null;
+  const statsWithTitle = await supabase
+    .from("character_stats")
+    .select("total_xp, current_level, streak_days, last_session_date, last_active_at, active_title")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (statsWithTitle.error) {
+    console.warn("[getProfile] stats+active_title fetch failed — retrying without active_title:", statsWithTitle.error.message);
+    const statsBasic = await supabase
+      .from("character_stats")
+      .select("total_xp, current_level, streak_days, last_session_date, last_active_at")
+      .eq("user_id", userId)
+      .maybeSingle();
+    statsData = statsBasic.data ? { ...statsBasic.data, active_title: null } : null;
+  } else {
+    statsData = statsWithTitle.data as Parameters<typeof rowsToProfile>[1];
+  }
 
   // Badge fetch is non-fatal — degrade to empty rather than crashing the profile load
   let badgeRows: EarnedBadge[] = [];
@@ -143,7 +180,7 @@ export async function getProfile(userId: string): Promise<PlayerProfile | null> 
 
   return rowsToProfile(
     userResult.data,
-    statsResult.data,
+    statsData,
     progressResult.data ?? [],
     badgeRows
   );
@@ -178,12 +215,14 @@ export async function completeLesson(
   score: number,
   xp: number
 ): Promise<LessonCompletionResult> {
-  // Pre-read attempts and last_session_date in parallel before any writes.
-  // Both reads must precede writes:
-  //   (1) attempts is used to compute currentAttempts+1 and isFirstAttempt before the upsert overwrites it
-  //   (2) last_session_date must be read before updateStreak() overwrites it with today
+  // Pre-read attempts, last_session_date, current_level, and hero_class in parallel before any writes.
+  // Reads must precede writes:
+  //   (1) attempts → isFirstAttempt check before upsert overwrites it
+  //   (2) last_session_date → comeback bonus check before updateStreak() overwrites it
+  //   (3) current_level → pre-write level baseline for evolution threshold detection (Unit 6)
+  //   (4) hero_class → needed for evolution detection
   const today = new Date().toISOString().split("T")[0];
-  const [existingProgressResult, statsPreResult] = await Promise.all([
+  const [existingProgressResult, statsPreResult, userPreResult] = await Promise.all([
     supabase
       .from("lesson_progress")
       .select("attempts")
@@ -192,8 +231,13 @@ export async function completeLesson(
       .maybeSingle(),
     supabase
       .from("character_stats")
-      .select("last_session_date")
+      .select("last_session_date, current_level")
       .eq("user_id", userId)
+      .maybeSingle(),
+    supabase
+      .from("users")
+      .select("hero_class")
+      .eq("id", userId)
       .maybeSingle(),
   ]);
 
@@ -210,6 +254,10 @@ export async function completeLesson(
     ? 1  // safe fallback: treat as already attempted — never over-award first-attempt bonus
     : (existingProgressResult.data?.attempts ?? 0);
   const isFirstAttempt = currentAttempts === 0;
+
+  // Pre-write level for evolution threshold comparison
+  const preLevelForEvolution = statsPreResult.data?.current_level ?? null;
+  const heroClassForEvolution = userPreResult.data?.hero_class ?? null;
 
   const lastSessionDate = statsPreResult.error
     ? null  // safe fallback: no comeback bonus on read failure
@@ -304,6 +352,7 @@ export async function completeLesson(
 
   // Badge check is non-fatal — a badge failure must not break lesson completion
   let newBadges: NewlyAwardedBadge[] = [];
+  let newTitle: string | undefined;
   if (!progressFetchError) {
     const completedSlugs = new Set(
       (allProgress ?? [])
@@ -311,7 +360,9 @@ export async function completeLesson(
         .map((r) => r.lesson_slug)
     );
     try {
-      newBadges = await checkAndAwardBadges(userId, completedSlugs);
+      const badgeResult = await checkAndAwardBadges(userId, completedSlugs);
+      newBadges = badgeResult.badges;
+      newTitle = badgeResult.newTitle;
     } catch (err) {
       console.error("[completeLesson] badge check failed — lesson completion still succeeds:", err);
     }
@@ -327,15 +378,75 @@ export async function completeLesson(
     console.error("[completeLesson] stats fetch failed:", statsResult.error.message);
   }
 
+  const newLevel = statsResult.data?.current_level ?? 1;
+
+  // Class evolution detection — non-fatal. Compare pre-write level vs post-write level.
+  // award_xp returns void — new level comes from the post-write SELECT above.
+  let classEvolved: LessonCompletionResult["classEvolved"] | undefined;
+  try {
+    if (preLevelForEvolution !== null && heroClassForEvolution !== null) {
+      const heroClass = toHeroClass(heroClassForEvolution);
+      const oldEvolution = getEvolvedClassName(heroClass, preLevelForEvolution);
+      const newEvolution = getEvolvedClassName(heroClass, newLevel);
+      if (oldEvolution !== newEvolution) {
+        classEvolved = { from: oldEvolution, to: newEvolution };
+      }
+    }
+  } catch (err) {
+    console.error("[completeLesson] evolution detection failed — lesson completion still succeeds:", err);
+  }
+
   return {
-    level: statsResult.data?.current_level ?? 1,
+    level: newLevel,
     streak: statsResult.data?.streak_days ?? 0,
     newBadges: newBadges.length > 0 ? newBadges : undefined,
     firstAttemptBonus: isFirstAttempt && firstAttemptBonusXp > 0
       ? { bonusXp: firstAttemptBonusXp }
       : undefined,
     comebackBonus: comebackBonusResult,
+    classEvolved,
+    newTitle,
   };
+}
+
+/**
+ * Persists the kid's active title choice.
+ * Validates that `title` is in the user's earned titles before writing.
+ * No-op (with console.warn) if title is not earned or is empty.
+ * Never throws — errors are logged.
+ */
+export async function setActiveTitle(userId: string, title: string): Promise<void> {
+  if (!title) {
+    console.warn("[setActiveTitle] empty title — skipping");
+    return;
+  }
+
+  // Validate against earned titles — must be earned, not just a valid title string
+  let earnedTitles: string[] = [];
+  try {
+    const badges = await getBadgesForUser(userId);
+    earnedTitles = getAvailableTitles(badges);
+  } catch (err) {
+    console.error("[setActiveTitle] badge fetch failed — cannot validate title:", err);
+    return;
+  }
+
+  if (!earnedTitles.includes(title)) {
+    console.warn(`[setActiveTitle] title "${title}" not earned by user ${userId} — skipping`);
+    return;
+  }
+
+  try {
+    const { error } = await supabase
+      .from("character_stats")
+      .update({ active_title: title })
+      .eq("user_id", userId);
+    if (error) {
+      console.error("[setActiveTitle] DB update failed:", error.message);
+    }
+  } catch (err) {
+    console.error("[setActiveTitle] unexpected error:", err);
+  }
 }
 
 async function updateStreak(userId: string): Promise<void> {

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -165,9 +165,16 @@ export async function getProfile(userId: string): Promise<PlayerProfile | null> 
       .select("total_xp, current_level, streak_days, last_session_date, last_active_at")
       .eq("user_id", userId)
       .maybeSingle();
+    if (statsBasic.error) {
+      console.error("[getProfile] fallback stats fetch also failed — profile will show zero stats:", statsBasic.error.message);
+    }
     statsData = statsBasic.data ? { ...statsBasic.data, active_title: null } : null;
   } else {
     statsData = statsWithTitle.data as Parameters<typeof rowsToProfile>[1];
+  }
+
+  if (progressResult.error) {
+    console.error("[getProfile] lesson_progress fetch failed — returning empty lessons:", progressResult.error.message);
   }
 
   // Badge fetch is non-fatal — degrade to empty rather than crashing the profile load
@@ -248,6 +255,9 @@ export async function completeLesson(
   }
   if (statsPreResult.error) {
     console.error("[completeLesson] stats pre-read failed — comeback bonus skipped:", statsPreResult.error.message);
+  }
+  if (userPreResult.error) {
+    console.error("[completeLesson] hero_class pre-read failed — evolution detection skipped:", userPreResult.error.message);
   }
 
   const currentAttempts = existingProgressResult.error
@@ -382,6 +392,8 @@ export async function completeLesson(
 
   // Class evolution detection — non-fatal. Compare pre-write level vs post-write level.
   // award_xp returns void — new level comes from the post-write SELECT above.
+  // NOTE: getEvolvedClassName and toHeroClass are documented as non-throwing (lib/classes.ts).
+  // The try/catch is a safety net in case that contract is broken by a future change.
   let classEvolved: LessonCompletionResult["classEvolved"] | undefined;
   try {
     if (preLevelForEvolution !== null && heroClassForEvolution !== null) {
@@ -415,10 +427,10 @@ export async function completeLesson(
  * No-op (with console.warn) if title is not earned or is empty.
  * Never throws — errors are logged.
  */
-export async function setActiveTitle(userId: string, title: string): Promise<void> {
+export async function setActiveTitle(userId: string, title: string): Promise<{ ok: true } | { ok: false; reason: string }> {
   if (!title) {
     console.warn("[setActiveTitle] empty title — skipping");
-    return;
+    return { ok: false, reason: "empty title" };
   }
 
   // Validate against earned titles — must be earned, not just a valid title string
@@ -428,12 +440,12 @@ export async function setActiveTitle(userId: string, title: string): Promise<voi
     earnedTitles = getAvailableTitles(badges);
   } catch (err) {
     console.error("[setActiveTitle] badge fetch failed — cannot validate title:", err);
-    return;
+    return { ok: false, reason: "badge fetch failed" };
   }
 
   if (!earnedTitles.includes(title)) {
     console.warn(`[setActiveTitle] title "${title}" not earned by user ${userId} — skipping`);
-    return;
+    return { ok: false, reason: "title not earned" };
   }
 
   try {
@@ -443,10 +455,13 @@ export async function setActiveTitle(userId: string, title: string): Promise<voi
       .eq("user_id", userId);
     if (error) {
       console.error("[setActiveTitle] DB update failed:", error.message);
+      return { ok: false, reason: error.message };
     }
   } catch (err) {
     console.error("[setActiveTitle] unexpected error:", err);
+    return { ok: false, reason: String(err) };
   }
+  return { ok: true };
 }
 
 async function updateStreak(userId: string): Promise<void> {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -194,7 +194,7 @@ export interface PlayerProfile {
   id: string;
   email: string;
   name: string;
-  heroClass: string;
+  heroClass: HeroClass;
   role: "parent" | "child";
   level: number;
   xp: number;
@@ -206,6 +206,11 @@ export interface PlayerProfile {
   unlockedToday: boolean;
   lessons: Record<string, LessonProgress>;
   badges: EarnedBadge[];
+  // Cosmetic identity fields (avatar tier, evolution, realm titles)
+  avatarTier: 1 | 2 | 3;
+  evolvedClassName: string;
+  activeTitle: string | null;
+  availableTitles: string[];
 }
 
 // Session stored in localStorage — login credentials, separate from game stats
@@ -239,6 +244,8 @@ export interface LessonCompletionResult {
   // Presence of the object is the flag — no separate isFirstAttempt boolean needed
   firstAttemptBonus?: { bonusXp: number };
   comebackBonus?: { daysAway: number; multiplier: ComebackMultiplier; bonusXp: number };
+  classEvolved?: { from: string; to: string };
+  newTitle?: string;
 }
 
 // Narrowed patch type for updateLessonProgress — only fields safe to update mid-session

--- a/supabase/migrations/007_active_title.sql
+++ b/supabase/migrations/007_active_title.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- KidKode — Migration 007: active_title on character_stats
+-- ============================================================
+-- Persists the kid's chosen realm title suffix.
+-- Nullable — existing users get NULL (renders as "no title" on dashboard).
+-- Auto-set by checkAndAwardBadges() when a realm badge is earned.
+-- Kid can cycle through earned titles from the dashboard.
+-- ============================================================
+
+ALTER TABLE public.character_stats
+  ADD COLUMN IF NOT EXISTS active_title TEXT DEFAULT NULL;
+
+-- Register in migration tracking
+INSERT INTO supabase_migrations.schema_migrations (version, name, statements)
+VALUES ('007', '007_active_title', ARRAY[
+  'ALTER TABLE public.character_stats ADD COLUMN IF NOT EXISTS active_title TEXT DEFAULT NULL'
+])
+ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
Closes #37.

## Summary

- Avatar now shows the kid's actual hero class emoji (🧙/🪖/🧝/🥷/🦸/🧜) with tier-based border/glow (tier 1 default, tier 2 purple at L5+, tier 3 gold at L10+)
- Hero class evolves at L5 and L10 — evolved name shown below hero name on dashboard, "EVOLVED!" card on UnlockScreen
- Each of the 6 realms grants a title suffix on completion; kid can tap to cycle earned titles; title auto-set when realm badge is awarded; "NEW TITLE!" card on UnlockScreen
- `CHARACTER_CLASSES` extracted to `lib/classes.ts` — single source of truth, replaces inline duplicates in `onboard/` and `parent/`

## Key Technical Decisions

- **Evolved class is computed, not stored** — `getEvolvedClassName(heroClass, level)` derives display name from stored `hero_class` + `current_level`. Zero new DB columns for class state.
- **Active title requires storage** — `active_title TEXT` on `character_stats` (migration 007), nullable. Returns `null` if migration not applied.
- **All new logic is non-fatal** — evolution detection, title auto-set, and title cycle server action each have independent try/catch. No new failure mode blocks lesson completion or badge award.
- **Pre-read extended** — `current_level` and `hero_class` added to `completeLesson()` pre-read block (alongside existing `last_session_date` and `attempts`) for evolution threshold detection.

## Migration Required

Apply migration 007 before this PR takes effect:
```
psql postgresql://postgres:postgres@localhost:55122/postgres -f supabase/migrations/007_active_title.sql
```

`getProfile()` has graceful fallback — retries stats SELECT without `active_title` if column missing, returns `null` for that field.

## Post-Deploy Monitoring & Validation

**Log queries to watch:**
- `[getProfile] stats+active_title fetch failed` — migration not applied; should stop after migration runs
- `[checkAndAwardBadges] active_title update failed` — title write failing (non-fatal)
- `[completeLesson] evolution detection failed` — evolution error (non-fatal)

**Healthy signals:** Dashboard renders without console errors; avatar emoji matches kid's class; `character_stats.active_title` populated after first realm completion; no regression in XP award, streak, or badge award.

**Failure signals:** If title update errors persist after migration, check `character_stats` write permissions. Migration is additive and reversible (`DROP COLUMN active_title`).

**Validation window:** First 24h after migration applied; owner: johnblythe
